### PR TITLE
chore: upgrade requirements for pii-annotations to use django 2.2

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,35 +4,33 @@
 #
 #    make upgrade
 #
-backports.entry-points-selectable==1.1.0
-    # via virtualenv
-certifi==2021.5.30
+certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.4
+charset-normalizer==2.0.11
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==5.5
+coverage==6.3
     # via codecov
-distlib==0.3.2
+distlib==0.3.4
     # via virtualenv
-filelock==3.0.12
+filelock==3.4.2
     # via
     #   tox
     #   virtualenv
-idna==3.2
+idna==3.3
     # via requests
-packaging==21.0
+packaging==21.3
     # via tox
-platformdirs==2.2.0
+platformdirs==2.4.1
     # via virtualenv
-pluggy==0.13.1
+pluggy==1.0.0
     # via tox
-py==1.10.0
+py==1.11.0
     # via tox
-pyparsing==2.4.7
+pyparsing==3.0.7
     # via packaging
-requests==2.26.0
+requests==2.27.1
     # via codecov
 six==1.16.0
     # via
@@ -40,13 +38,13 @@ six==1.16.0
     #   virtualenv
 toml==0.10.2
     # via tox
-tox==3.24.3
+tox==3.24.5
     # via
     #   -r requirements/ci.in
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.6
+urllib3==1.26.8
     # via requests
-virtualenv==20.7.2
+virtualenv==20.13.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,14 +16,10 @@ astroid==2.3.3
     # via
     #   pylint
     #   pylint-celery
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   -r requirements/test.txt
     #   pytest
-backports.entry-points-selectable==1.1.0
-    # via
-    #   -r requirements/ci.txt
-    #   virtualenv
 billiard==3.6.4.0
     # via
     #   -r requirements/test.txt
@@ -32,19 +28,19 @@ celery==4.4.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
-certifi==2021.5.30
+certifi==2021.10.8
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   requests
 chardet==4.0.0
     # via diff-cover
-charset-normalizer==2.0.4
+charset-normalizer==2.0.11
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   requests
-click==8.0.1
+click==8.0.3
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/test.txt
@@ -58,26 +54,27 @@ code-annotations==1.2.0
     # via -r requirements/test.txt
 codecov==2.1.12
     # via -r requirements/ci.txt
-coverage==5.5
+coverage[toml]==6.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   codecov
     #   pytest-cov
-ddt==1.4.2
+ddt==1.4.4
     # via -r requirements/test.txt
-diff-cover==6.3.4
+diff-cover==6.4.4
     # via -r requirements/dev.in
-distlib==0.3.2
+distlib==0.3.4
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==2.2.24
+django==2.2.26
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   django-crum
     #   django-model-utils
+    #   django-solo
     #   djangorestframework
     #   edx-django-utils
     #   edx-i18n-tools
@@ -85,46 +82,44 @@ django-crum==0.7.9
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via -r requirements/test.txt
-django-solo==1.1.5
+django-solo==2.0.0
     # via -r requirements/test.txt
-django-waffle==2.2.1
+django-waffle==2.3.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via -r requirements/test.txt
-edx-django-utils==4.3.0
+edx-django-utils==4.4.2
     # via
     #   -r requirements/test.txt
     #   edx-rest-api-client
-edx-i18n-tools==0.7.0
+edx-i18n-tools==0.8.1
     # via -r requirements/dev.in
 edx-lint==1.5.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/dev.in
-edx-rest-api-client==5.4.0
+edx-rest-api-client==5.5.0
     # via -r requirements/test.txt
-factory-boy==3.2.0
+factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==8.12.1
+faker==11.3.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.0.12
+filelock==3.4.2
     # via
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
-idna==3.2
+idna==3.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   requests
-inflect==5.3.0
-    # via jinja2-pluralize
 iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
@@ -133,14 +128,11 @@ isort==4.3.21
     # via
     #   -r requirements/dev.in
     #   pylint
-jinja2==3.0.1
+jinja2==3.0.3
     # via
     #   -r requirements/test.txt
     #   code-annotations
     #   diff-cover
-    #   jinja2-pluralize
-jinja2-pluralize==0.3.0
-    # via diff-cover
 kombu==4.6.11
     # via
     #   -r requirements/test.txt
@@ -155,11 +147,11 @@ mccabe==0.6.1
     # via pylint
 mock==4.0.3
     # via -r requirements/test.txt
-newrelic==6.8.1.164
+newrelic==7.4.0.172
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-packaging==21.0
+packaging==21.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -169,21 +161,21 @@ path==13.1.0
     # via
     #   -c requirements/constraints.txt
     #   edx-i18n-tools
-pbr==5.6.0
+pbr==5.8.0
     # via
     #   -r requirements/test.txt
     #   stevedore
-pep517==0.11.0
+pep517==0.12.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-pip-tools==6.2.0
+pip-tools==6.4.0
     # via -r requirements/pip-tools.txt
-platformdirs==2.2.0
+platformdirs==2.4.1
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-pluggy==0.13.1
+pluggy==1.0.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -192,23 +184,23 @@ pluggy==0.13.1
     #   tox
 polib==1.1.1
     # via edx-i18n-tools
-psutil==5.8.0
+psutil==5.9.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-py==1.10.0
+py==1.11.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   pytest
     #   tox
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via -r requirements/dev.in
 pydocstyle==6.1.1
     # via -r requirements/dev.in
-pygments==2.10.0
+pygments==2.11.2
     # via diff-cover
-pyjwt==2.1.0
+pyjwt==2.3.0
     # via
     #   -r requirements/test.txt
     #   edx-rest-api-client
@@ -222,23 +214,23 @@ pylint-celery==0.3
     # via edx-lint
 pylint-django==2.0.11
     # via edx-lint
-pylint-plugin-utils==0.6
+pylint-plugin-utils==0.7
     # via
     #   pylint-celery
     #   pylint-django
-pyparsing==2.4.7
+pyparsing==3.0.7
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   packaging
-pytest==6.2.4
+pytest==6.2.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==2.12.1
+pytest-cov==3.0.0
     # via -r requirements/test.txt
-pytest-django==4.4.0
+pytest-django==4.5.2
     # via -r requirements/test.txt
 python-dateutil==2.8.2
     # via
@@ -248,17 +240,18 @@ python-slugify==5.0.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
-pytz==2021.1
+pytz==2021.3
     # via
     #   -r requirements/test.txt
     #   celery
     #   django
-pyyaml==5.4.1
+    #   djangorestframework
+pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
     #   edx-i18n-tools
-requests==2.26.0
+requests==2.27.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -267,14 +260,13 @@ requests==2.26.0
     #   edx-rest-api-client
     #   responses
     #   slumber
-responses==0.13.4
+responses==0.17.0
     # via -r requirements/test.txt
 six==1.16.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   astroid
-    #   edx-i18n-tools
     #   edx-lint
     #   python-dateutil
     #   responses
@@ -284,18 +276,18 @@ slumber==0.7.1
     # via
     #   -r requirements/test.txt
     #   edx-rest-api-client
-snowballstemmer==2.1.0
+snowballstemmer==2.2.0
     # via pydocstyle
-sqlparse==0.4.1
+sqlparse==0.4.2
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
     #   edx-django-utils
-testfixtures==6.18.1
+testfixtures==6.18.3
     # via -r requirements/test.txt
 text-unidecode==1.3
     # via
@@ -307,13 +299,14 @@ toml==0.10.2
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   pytest
-    #   pytest-cov
     #   tox
-tomli==1.2.1
+tomli==2.0.0
     # via
     #   -r requirements/pip-tools.txt
+    #   -r requirements/test.txt
+    #   coverage
     #   pep517
-tox==3.24.3
+tox==3.24.5
     # via
     #   -r requirements/ci.txt
     #   tox-battery
@@ -321,7 +314,7 @@ tox-battery==0.6.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/dev.in
-urllib3==1.26.6
+urllib3==1.26.8
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -332,11 +325,11 @@ vine==1.3.0
     #   -r requirements/test.txt
     #   amqp
     #   celery
-virtualenv==20.7.2
+virtualenv==20.13.0
     # via
     #   -r requirements/ci.txt
     #   tox
-wheel==0.37.0
+wheel==0.37.1
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,15 +4,15 @@
 #
 #    make upgrade
 #
-click==8.0.1
+click==8.0.3
     # via pip-tools
-pep517==0.11.0
+pep517==0.12.0
     # via pip-tools
-pip-tools==6.2.0
+pip-tools==6.4.0
     # via -r requirements/pip-tools.in
-tomli==1.2.1
+tomli==2.0.0
     # via pep517
-wheel==0.37.0
+wheel==0.37.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.37.0
+wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.2.4
+pip==22.0.2
     # via -r requirements/pip.in
-setuptools==57.4.0
+setuptools==60.6.0
     # via -r requirements/pip.in

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -3,6 +3,7 @@
 
 -r base.in                # Core dependencies for this package
 
+django>=2.2,<2.3
 pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
 code-annotations          # provides commands used by the pii_check make target.

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,7 +10,7 @@ algoliasearch==1.20.0
     #   -r requirements/base.in
 amqp==2.6.1
     # via kombu
-attrs==21.2.0
+attrs==21.4.0
     # via pytest
 billiard==3.6.4.0
     # via celery
@@ -18,52 +18,54 @@ celery==4.4.7
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-certifi==2021.5.30
+certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.4
+charset-normalizer==2.0.11
     # via requests
-click==8.0.1
+click==8.0.3
     # via code-annotations
 code-annotations==1.2.0
     # via -r requirements/test.in
-coverage==5.5
+coverage[toml]==6.3
     # via pytest-cov
-ddt==1.4.2
+ddt==1.4.4
     # via -r requirements/test.in
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
+    #   -r requirements/test.in
     #   django-crum
     #   django-model-utils
+    #   django-solo
     #   djangorestframework
     #   edx-django-utils
 django-crum==0.7.9
     # via edx-django-utils
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via -r requirements/base.in
-django-solo==1.1.5
+django-solo==2.0.0
     # via -r requirements/base.in
-django-waffle==2.2.1
+django-waffle==2.3.0
     # via edx-django-utils
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via -r requirements/base.in
-edx-django-utils==4.3.0
+edx-django-utils==4.4.2
     # via
     #   -r requirements/base.in
     #   edx-rest-api-client
-edx-rest-api-client==5.4.0
+edx-rest-api-client==5.5.0
     # via -r requirements/base.in
-factory-boy==3.2.0
+factory-boy==3.2.1
     # via -r requirements/test.in
-faker==8.12.1
+faker==11.3.0
     # via
     #   -r requirements/test.in
     #   factory-boy
-idna==3.2
+idna==3.3
     # via requests
 iniconfig==1.1.1
     # via pytest
-jinja2==3.0.1
+jinja2==3.0.3
     # via code-annotations
 kombu==4.6.11
     # via celery
@@ -71,48 +73,49 @@ markupsafe==2.0.1
     # via jinja2
 mock==4.0.3
     # via -r requirements/test.in
-newrelic==6.8.1.164
+newrelic==7.4.0.172
     # via edx-django-utils
-packaging==21.0
+packaging==21.3
     # via pytest
-pbr==5.6.0
+pbr==5.8.0
     # via stevedore
-pluggy==0.13.1
+pluggy==1.0.0
     # via pytest
-psutil==5.8.0
+psutil==5.9.0
     # via edx-django-utils
-py==1.10.0
+py==1.11.0
     # via pytest
-pyjwt==2.1.0
+pyjwt==2.3.0
     # via edx-rest-api-client
-pyparsing==2.4.7
+pyparsing==3.0.7
     # via packaging
-pytest==6.2.4
+pytest==6.2.5
     # via
     #   pytest-cov
     #   pytest-django
-pytest-cov==2.12.1
+pytest-cov==3.0.0
     # via -r requirements/test.in
-pytest-django==4.4.0
+pytest-django==4.5.2
     # via -r requirements/test.in
 python-dateutil==2.8.2
     # via faker
 python-slugify==5.0.2
     # via code-annotations
-pytz==2021.1
+pytz==2021.3
     # via
     #   -r requirements/base.in
     #   celery
     #   django
-pyyaml==5.4.1
+    #   djangorestframework
+pyyaml==6.0
     # via code-annotations
-requests==2.26.0
+requests==2.27.1
     # via
     #   algoliasearch
     #   edx-rest-api-client
     #   responses
     #   slumber
-responses==0.13.4
+responses==0.17.0
     # via -r requirements/test.in
 six==1.16.0
     # via
@@ -120,23 +123,23 @@ six==1.16.0
     #   responses
 slumber==0.7.1
     # via edx-rest-api-client
-sqlparse==0.4.1
+sqlparse==0.4.2
     # via django
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   code-annotations
     #   edx-django-utils
-testfixtures==6.18.1
+testfixtures==6.18.3
     # via -r requirements/test.in
 text-unidecode==1.3
     # via
     #   faker
     #   python-slugify
 toml==0.10.2
-    # via
-    #   pytest
-    #   pytest-cov
-urllib3==1.26.6
+    # via pytest
+tomli==2.0.0
+    # via coverage
+urllib3==1.26.8
     # via
     #   requests
     #   responses


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [ ] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.