### PR TITLE
feat: use program update signal to call EMSI API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,12 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 
 Unreleased
---------------------
+---------------------
+[1.17.1] - 2022-07-29
+---------------------
+
+* feat: use program update signal to call EMSI API
+
 [1.17.0] - 2022-07-15
 ---------------------
 

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.17.0'
+__version__ = '1.17.1'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/signals/handlers.py
+++ b/taxonomy/signals/handlers.py
@@ -8,7 +8,7 @@ from django.dispatch import receiver
 
 from taxonomy.tasks import update_course_skills
 
-from .signals import UPDATE_COURSE_SKILLS
+from .signals import UPDATE_COURSE_SKILLS, UPDATE_PROGRAM_SKILLS
 
 LOGGER = logging.getLogger(__name__)
 
@@ -20,3 +20,11 @@ def handle_update_course_skills(sender, course_uuid, **kwargs):  # pylint: disab
     """
     LOGGER.info('[TAXONOMY] UPDATE_COURSE_SKILLS signal received')
     update_course_skills.delay([course_uuid])
+
+
+@receiver(UPDATE_PROGRAM_SKILLS)
+def handle_update_program_skills(sender, program_uuid, **kwargs):  # pylint: disable=unused-argument
+    """
+    Handle signal and trigger task to update program skills.
+    """
+    # TODO: to be added in https://2u-internal.atlassian.net/browse/PROD-2904

--- a/taxonomy/signals/signals.py
+++ b/taxonomy/signals/signals.py
@@ -6,3 +6,4 @@ This module contains taxonomy related signals.
 from django.dispatch import Signal
 
 UPDATE_COURSE_SKILLS = Signal()
+UPDATE_PROGRAM_SKILLS = Signal()


### PR DESCRIPTION
[PROD-2902](https://2u-internal.atlassian.net/browse/PROD-2902)
Adds a django signal triggered by Discovery (added in https://github.com/openedx/course-discovery/pull/3539). This signal will be used to call EMSI Api to update skills for Programs.

**Merge checklist:**
- [x] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.