### PR TITLE
feat: update skill serializer to include category and subcategory details

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,12 +12,12 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 
 Unreleased
----------------------
+--------------------
 
-[1.18.0] - 2022-07-29
+[1.18.0] - 2022-08-01
 ---------------------
-
-* feat: feat: add program skill model
+* feat: add program skill model
+* feat: Update SkillSerializer to include Category and Subcategory details.
 
 [1.17.1] - 2022-07-29
 ---------------------

--- a/taxonomy/serializers.py
+++ b/taxonomy/serializers.py
@@ -4,7 +4,37 @@ Serializers for taxonomy.
 
 from rest_framework import serializers
 
-from taxonomy.models import Skill
+from taxonomy.models import Skill, SkillCategory, SkillSubCategory
+
+
+class SkillCategorySerializer(serializers.ModelSerializer):
+    """
+    Skill Category model serializer.
+    """
+
+    class Meta:
+        """
+        Meta definition for SkillCategorySerializer.
+        """
+
+        model = SkillCategory
+        fields = ('name',)
+
+
+class SkillSubCategorySerializer(serializers.ModelSerializer):
+    """
+    Skill SubCategory model serializer.
+    """
+
+    category = SkillCategorySerializer()
+
+    class Meta:
+        """
+        Meta definition for SkillSubCategorySerializer.
+        """
+
+        model = SkillSubCategory
+        fields = ('name', 'category')
 
 
 class SkillSerializer(serializers.ModelSerializer):
@@ -12,10 +42,13 @@ class SkillSerializer(serializers.ModelSerializer):
     Serializer for the Skill model.
     """
 
+    category = SkillCategorySerializer()
+    subcategory = SkillSubCategorySerializer()
+
     class Meta:
         """
         Metadata for SkillSerializer.
         """
 
         model = Skill
-        fields = ('name', 'description')
+        fields = ('name', 'description', 'category', 'subcategory')


### PR DESCRIPTION
### [PROD-2890](https://2u-internal.atlassian.net/browse/PROD-2890)

### Description
Update the skill serializer to include category and sub-category details. If either is missing, null is provided in the data. This new format is intended for use in Algolia models in discovery.


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [x] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.