### PR TITLE
feat: cache serialized course skills

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 
+[1.20.0] - 2022-08-11
+---------------------
+* feat: add caching to ``utils.get_whitelisted_serialized_skills()``
+
 [1.19.0] - 2022-08-04
 ---------------------
 * feat: add provider and validator for Programs

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ requirements: ## install development environment requirements
 	pip-sync requirements/dev.txt
 
 test: clean ## run tests in the current virtualenv
-	pytest
+	DJANGO_SETTINGS_MODULE=test_settings pytest
 
 diff_cover: test ## find diff lines that need test coverage
 	diff-cover coverage.xml

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.19.0'
+__version__ = '1.20.0'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
This will help performance related to jobs that have to fetch a lot of the
same course data multiple times during a single run.

https://2u-internal.atlassian.net/browse/ENT-6169

## How to test locally
* Check out this branch.
* From devstack, do `make dev.up.discovery`, make sure the elasticsearch container starts up.
* `make discovery-shell` and then `pip install -e /edx/src/taxonomy-connector` to install these changes locally in editable mode.
* (possibly) restart discovery devserver `make discovery-restart-devserver`
* Make a request to the `/search/all` endpoint, curl command copied below

```
curl --location --request POST 'http://localhost:18381/api/v1/search/all/?page_size=10' \
--header 'Authorization: JWT [your-jwt-here]' \
--header 'Content-Type: application/json' \
--data-raw '{
    "content_type":"course",
    "partner":"edx",
    "level_type":[
        "Introductory",
        "Intermediate",
        "Advanced"
    ],
    "availability":[
        "Current",
        "Starting Soon",
        "Upcoming"
    ],
    "status":"published"
}'
```

Now you wanna make sure your skills list made it into the cache.  From a discovery shell again, start a Django shell `./manage.py shell` and do this:
```python
>>> from django.core.cache import cache
>>> from edx_django_utils.cache import utils
>>> course_key = "course-id+qSRfdlWtAkIJ"  # change this to a course key you have in your devstack
>>> key = utils.get_cache_key(domain='taxonomy', subdomain='course_skills', course_key=course_key)
>>> key
'87b5f7ed204132baae9ff9d95824ad23'
>>> cache.get(key)
[]
```
An empty list is a totally fine response, here - you likely don't have any skills data set up locally.  What we're checking here is that we get a cache hit after making the first request to `/search/all` (whose response includes serialized data for the course you're checking the cache for).
**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [x] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.