### PR TITLE
feat: Add ID of job in serializer for Algolia

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 
+[1.22.1] - 2022-08-26
+---------------------
+* Added id field in JobSerializer for Algolia.
+
 [1.22.0] - 2022-08-22
 ---------------------
 * Added a new model for storing user response for skills quiz.

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.22.0'
+__version__ = '1.22.1'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/algolia/serializers.py
+++ b/taxonomy/algolia/serializers.py
@@ -40,7 +40,7 @@ class JobSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Job
-        fields = ('external_id', 'name', 'skills', 'job_postings', 'objectID')
+        fields = ('id', 'external_id', 'name', 'skills', 'job_postings', 'objectID')
         read_only_fields = fields
 
     def get_objectID(self, obj):  # pylint: disable=invalid-name

--- a/tests/algolia/test_serializers.py
+++ b/tests/algolia/test_serializers.py
@@ -32,6 +32,9 @@ class TestJobSerializer(TaxonomyTestCase):
         # Assert all jobs are included in the data returned by the serializer
         assert len(jobs_data) == 15
 
+        # Assert ID is present
+        assert all('id' in job_data for job_data in jobs_data)
+
         # Assert Object ID is present
         assert all('objectID' in job_data for job_data in jobs_data)
 


### PR DESCRIPTION
**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [x] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.

Data in algolia with id
![Screenshot 2022-08-26 at 4 48 02 PM](https://user-images.githubusercontent.com/49611774/186896891-5551ff2e-71c8-4140-9e36-f792002b303c.png)

