### PR TITLE
fix: add default values and bump version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 
+[1.22.4] - 2022-09-14
+---------------------
+* Updated utils to support program skills.
+
 [1.22.3] - 2022-09-07
 ---------------------
 * Added support to filter Skills by names.

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.22.3'
+__version__ = '1.22.4'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/choices.py
+++ b/taxonomy/choices.py
@@ -13,3 +13,12 @@ class UserGoal(DjangoChoices):
     GetPromoted = ChoiceItem('get_promoted', 'I want to get promoted')
     ImproveCurrentRole = ChoiceItem('improve_current_role', 'I want to improve at my current role')
     Other = ChoiceItem('other', 'Other')
+
+
+class ProductTypes(DjangoChoices):
+    """
+    Product types to be used in retrieving skills.
+    """
+
+    Course = ChoiceItem('course', 'Course')
+    Program = ChoiceItem('program', 'Program')

--- a/taxonomy/utils.py
+++ b/taxonomy/utils.py
@@ -8,6 +8,7 @@ import boto3
 from bs4 import BeautifulSoup
 from edx_django_utils.cache import get_cache_key, TieredCache
 
+from taxonomy.choices import ProductTypes
 from taxonomy.constants import (
     AMAZON_TRANSLATION_ALLOWED_SIZE,
     AUTO,
@@ -25,7 +26,7 @@ LOGGER = logging.getLogger(__name__)
 CACHE_TIMEOUT_COURSE_SKILLS_SECONDS = 60 * 60
 
 
-def get_whitelisted_serialized_skills(key_or_uuid, product_type):
+def get_whitelisted_serialized_skills(key_or_uuid, product_type=ProductTypes.Course):
     """
     Get a list of serialized course skills.
 
@@ -253,12 +254,13 @@ def is_skill_blacklisted(key_or_uuid, skill_id, product_type):
     return skill_model.objects.filter(**kwargs).exists()
 
 
-def get_whitelisted_product_skills(key_or_uuid, product_type, prefetch_skills=True):
+def get_whitelisted_product_skills(key_or_uuid, product_type=ProductTypes.Course, prefetch_skills=True):
     """
     Get all the product skills that are not blacklisted.
 
     Arguments:
         key_or_uuid (str): Key or uuid of the product whose skills need to be returned.
+        product_type (str): String indicating about the product type.
         prefetch_skills (bool): If True, Prefetch related skills in a single query using Django's select_related.
 
     Returns:
@@ -292,12 +294,13 @@ def get_blacklisted_course_skills(course_key, prefetch_skills=True):
     return qs.all()
 
 
-def get_course_jobs(course_key, product_type):
+def get_course_jobs(course_key, product_type=ProductTypes.Course):
     """
     Get data for all course jobs.
 
     Arguments:
         course_key (str): Key of the course whose course skills need to be returned.
+        product_type (str): String indicating about the product type.
 
     Returns:
         list: A list of dicts where each dict contain information about a particular job.


### PR DESCRIPTION
Fixing #109 by adding default values to the util functions.
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [ ] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.