### PR TITLE
feat: Expand course skills tagging to include title, short_description and full_description.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 
+[1.23.0] - 2022-10-05
+---------------------
+* Expand course skills tagging to include `title`, `short_description` and `full_description`.
+
 [1.22.5] - 2022-09-16
 ---------------------
 * Fixes product type issue by using ProductTypes choices.

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.22.5'
+__version__ = '1.23.0'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/tests/management/test_refresh_course_skills.py
+++ b/tests/management/test_refresh_course_skills.py
@@ -81,6 +81,8 @@ class RefreshCourseSkillsCommandTests(TaxonomyTestCase):
         """
         Test that command work as expected if course description does not exist.
         """
+        self.course_1.title = ''
+        self.course_1.short_description = ''
         self.course_1.full_description = ''
         self.course_1.save()
         get_course_provider_mock.return_value = DiscoveryCourseMetadataProvider([self.course_1])

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -415,7 +415,7 @@ class TestUtils(TaxonomyTestCase):
         }
         factories.TranslationFactory(
             source_record_identifier=COURSE_KEY,
-            source_model_field='full_description',
+            source_model_field=utils.COURSE_METADATA_FIELDS_COMBINED,
             source_model_name=product_type,
             source_text=existing_course_description,
             translated_text=existing_translation,
@@ -428,7 +428,7 @@ class TestUtils(TaxonomyTestCase):
         )
         translation_record = Translation.objects.filter(
             source_model_name=product_type,
-            source_model_field='full_description',
+            source_model_field=utils.COURSE_METADATA_FIELDS_COMBINED,
             source_record_identifier=COURSE_KEY
         ).first()
 
@@ -456,7 +456,7 @@ class TestUtils(TaxonomyTestCase):
         }
         factories.TranslationFactory(
             source_record_identifier=COURSE_KEY,
-            source_model_field='full_description',
+            source_model_field=utils.COURSE_METADATA_FIELDS_COMBINED,
             source_model_name=product_type,
             source_text=existing_course_description,
             translated_text=existing_translation,
@@ -468,7 +468,7 @@ class TestUtils(TaxonomyTestCase):
         )
         translation_record = Translation.objects.filter(
             source_model_name=product_type,
-            source_model_field='full_description',
+            source_model_field=utils.COURSE_METADATA_FIELDS_COMBINED,
             source_record_identifier=COURSE_KEY
         ).first()
 
@@ -491,7 +491,7 @@ class TestUtils(TaxonomyTestCase):
         }
         trans = factories.TranslationFactory(
             source_record_identifier=COURSE_KEY,
-            source_model_field='full_description',
+            source_model_field=utils.COURSE_METADATA_FIELDS_COMBINED,
             source_model_name=product_type,
             source_text=course_description,
             translated_text=translated_course_description,
@@ -504,7 +504,7 @@ class TestUtils(TaxonomyTestCase):
         )
         translation_record = Translation.objects.filter(
             source_model_name=product_type,
-            source_model_field='full_description',
+            source_model_field=utils.COURSE_METADATA_FIELDS_COMBINED,
             source_record_identifier=COURSE_KEY
         ).exists()
         assert translation_record is True
@@ -586,7 +586,7 @@ class TestUtils(TaxonomyTestCase):
         )
         translation_record = Translation.objects.filter(
             source_model_name=product_type,
-            source_model_field='full_description',
+            source_model_field='title:short_description:full_description',
             source_record_identifier=COURSE_KEY
         ).first()
 
@@ -612,7 +612,7 @@ class TestUtils(TaxonomyTestCase):
         )
         translation_record = Translation.objects.filter(
             source_model_name=product_type,
-            source_model_field='full_description',
+            source_model_field=utils.COURSE_METADATA_FIELDS_COMBINED,
             source_record_identifier=COURSE_KEY
         ).first()
 
@@ -639,7 +639,7 @@ class TestUtils(TaxonomyTestCase):
         )
         translation_record = Translation.objects.filter(
             source_model_name=product_type,
-            source_model_field='full_description',
+            source_model_field=utils.COURSE_METADATA_FIELDS_COMBINED,
             source_record_identifier=COURSE_KEY
         ).first()
 
@@ -667,7 +667,7 @@ class TestUtils(TaxonomyTestCase):
         }
         factories.TranslationFactory(
             source_record_identifier=COURSE_KEY,
-            source_model_field='full_description',
+            source_model_field=utils.COURSE_METADATA_FIELDS_COMBINED,
             source_model_name=product_type,
             source_text=existing_course_description,
             translated_text=existing_translation,
@@ -680,7 +680,7 @@ class TestUtils(TaxonomyTestCase):
         )
         translation_record = Translation.objects.filter(
             source_model_name=product_type,
-            source_model_field='full_description',
+            source_model_field=utils.COURSE_METADATA_FIELDS_COMBINED,
             source_record_identifier=COURSE_KEY
         ).first()
 
@@ -708,7 +708,13 @@ class TestUtils(TaxonomyTestCase):
         courses = []
         for _ in range(11):
             course = MockCourse()
-            courses.append(course)
+            courses.append({
+                'uuid': course.uuid,
+                'key': course.key,
+                'title': course.title,
+                'short_description': course.short_description,
+                'full_description': course.full_description,
+            })
 
         utils.refresh_product_skills(courses, False, product_type)
 


### PR DESCRIPTION
**JIRA:** https://2u-internal.atlassian.net/browse/ENT-6293

**Description:** We currently only use `full_description` field of a course for skill tagging but we believe that including course `title` and `short_description` fields can generate and improve course skill tagging and cover more use cases.



**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [ ] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.