### PR TITLE
fix: misc fixes for course skill tagging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Change Log
 
 Unreleased
 
+[1.23.1] - 2022-10-13
+---------------------
+* Do no concatenate if `short_description is `None`.
+* Fix CourseSkills update_or_create call.
+
 [1.23.0] - 2022-10-05
 ---------------------
 * Expand course skills tagging to include `title`, `short_description` and `full_description`.

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.23.0'
+__version__ = '1.23.1'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/utils.py
+++ b/taxonomy/utils.py
@@ -93,10 +93,12 @@ def update_skills_data(key_or_uuid, skill_external_id, confidence, skill_data, p
     kwargs = {
         identifier: key_or_uuid,
         'skill': skill,
+    }
+    defaults = {
         'confidence': confidence
     }
     if not is_skill_blacklisted(key_or_uuid, skill.id, product_type):
-        _, created = skill_model.objects.update_or_create(**kwargs)
+        _, created = skill_model.objects.update_or_create(**kwargs, defaults=defaults)
         action = 'created' if created else 'updated'
         LOGGER.error(f'{skill_model} {action} for key {key_or_uuid}')
 
@@ -154,7 +156,7 @@ def get_course_metadata_fields_text(course_attrs_string, course):
     course_attr_values = []
     for course_attr in course_attrs_string.split(':'):
         course_attr_values.append(course[course_attr])
-    return ' '.join(course_attr_values).strip()
+    return ' '.join(filter(bool, course_attr_values)).strip()
 
 
 def refresh_product_skills(products, should_commit_to_db, product_type):


### PR DESCRIPTION
**Description:**
* Do no concatenate if short_description is None.
* Fix CourseSkills update_or_create call.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [ ] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.