### PR TITLE
Industry name in JobSkills Algolia Serializer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Change Log
 
 Unreleased
 
+[1.28.2] - 2022-11-23
+---------------------
+* Added industry_names field in Algolia serializer.
+
+
 [1.28.1] - 2022-11-22
 ---------------------
 * Added JobHolderUsernamesAPIView which returns a list of 100 usernames from SkillsQuiz.

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.28.1'
+__version__ = '1.28.2'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/tests/algolia/test_utils.py
+++ b/tests/algolia/test_utils.py
@@ -43,6 +43,8 @@ class TestUtils(TaxonomyTestCase):
         assert all('median_salary' in job_data['job_postings'][0] for job_data in jobs_data)
         assert all('job_id' in job_data['job_postings'][0] for job_data in jobs_data)
 
+        assert all('industry_names' in job_data for job_data in jobs_data)
+
     @mock.patch('taxonomy.algolia.utils.JOBS_PAGE_SIZE', 5)  # this is done to trigger the pagination flow.
     @mock.patch('taxonomy.algolia.client.algoliasearch.Client')
     def test_index_jobs_data_in_algolia(self, algolia_search_client_mock):


### PR DESCRIPTION
# Discussion
This PR adds industry names in the industry_names field in `JobSerializer` which contains the industry names in which the job belongs. The Jira ticket has decided structure of serializer. 

JIRA: [ENT-6411](https://2u-internal.atlassian.net/browse/ENT-6411)

## Algolia Index
Some of the screenshots of Algolia index with data from local database. 

Job which is not linked to any industry. 
<img width="492" alt="Screenshot 2022-11-23 at 2 18 41 PM" src="https://user-images.githubusercontent.com/106396899/203510547-421af614-9181-41e3-8e6f-6f46410527f4.png">

Jobs which are linked to some industries. 
<img width="493" alt="Screenshot 2022-11-23 at 2 04 26 PM" src="https://user-images.githubusercontent.com/106396899/203510680-761f6788-c3ec-47b0-9ad7-6da8801a28b0.png">

<img width="493" alt="Screenshot 2022-11-23 at 2 02 02 PM" src="https://user-images.githubusercontent.com/106396899/203510656-caf6a22c-7533-4870-9061-5f9064bdfc33.png">


**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [x] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.