### PR TITLE
feat: Updated refresh_job_skills command to save industry relation with job and skills.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,12 @@ Change Log
 
 Unreleased
 
-[1.26.0] - 2022-10-31
+[1.28.0] - 2022-11-21
+---------------------
+* Updated refresh_job_skills command to save industry relation with job and skills.
+
+
+[1.27.0] - 2022-10-31
 ---------------------
 * Removed industry foreign key from JobSkills table and create a new table IndustryJobSkill.
 

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.27.0'
+__version__ = '1.28.0'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/constants.py
+++ b/taxonomy/constants.py
@@ -18,12 +18,13 @@ def get_lookup_query_filter(external_ids):
     return lookup_query_filter
 
 
-def get_job_query_filter(skills=None):
+def get_job_query_filter(skills=None, industry=None):
     """
     Build job query filter to be used in fetching jobs data from the EMSI Service.
 
     Arguments:
         skills (list): jobs external ids to add in filter
+        industry (Industry): Industry object to add in filter
 
     Returns:
         dict: Job postings query filter to used in EMSI API
@@ -37,7 +38,7 @@ def get_job_query_filter(skills=None):
             },
         },
         # we are using TITLE facet for `rank` and SKILLS facet for the `nested rank`
-        # for every skills batch in our system (let say 100 skills) we are getting top 100 jobs by `unique_postings`
+        # for every skill's batch in our system (let say 50 skills) we are getting top 100 jobs by `unique_postings`
         # and 10 skills per every job ranked by significance.
         'rank': {   # jobs
             'by': 'unique_postings',
@@ -53,6 +54,12 @@ def get_job_query_filter(skills=None):
             'include': skills,
             'include_op': 'or'
         }
+    if industry:
+        jobs_query_filter['filter']['naics2'] = {
+            'include': [str(industry.code)]
+        }
+        jobs_query_filter['rank']['limit'] = 25  # for every batch get top 25 jobs
+        jobs_query_filter['nested_rank']['limit'] = 10  # for every job get top 10 skills
     return jobs_query_filter
 
 

--- a/tests/management/test_refresh_job_skills.py
+++ b/tests/management/test_refresh_job_skills.py
@@ -16,7 +16,7 @@ from django.utils.translation import gettext as _
 
 from taxonomy.enums import RankingFacet
 from taxonomy.exceptions import TaxonomyAPIError
-from taxonomy.models import Job, JobSkills, Skill
+from taxonomy.models import Job, JobSkills, Skill, Industry, IndustryJobSkill
 from test_utils.factories import SkillFactory
 from test_utils.sample_responses.jobs import JOBS, MISSING_SIGNIFICANCE_KEY_JOBS
 from test_utils.testcase import TaxonomyTestCase
@@ -50,6 +50,7 @@ class RefreshJobSkillsCommandTests(TaxonomyTestCase):
         get_job_skills_mock.return_value = self.jobs
         expected_job_count = 2
         expected_job_skill_count = 4
+        industry_count = Industry.objects.count()
 
         if missing_skill:
             # remove one skill
@@ -59,11 +60,13 @@ class RefreshJobSkillsCommandTests(TaxonomyTestCase):
 
         self.assertEqual(Job.objects.count(), 0)
         self.assertEqual(JobSkills.objects.count(), 0)
+        self.assertEqual(IndustryJobSkill.objects.count(), 0)
 
         call_command(self.command)
 
         self.assertEqual(Job.objects.all().count(), expected_job_count)
         self.assertEqual(JobSkills.objects.all().count(), expected_job_skill_count)
+        self.assertEqual(IndustryJobSkill.objects.all().count(), industry_count * expected_job_skill_count)
 
     @responses.activate
     @mock.patch('taxonomy.management.commands.refresh_job_skills.EMSIJobsApiClient.get_jobs')


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-6410

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [ ] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.