### PR TITLE
fix: handle repeating industry names in algolia index and test

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 
+[1.31.1] - 2022-12-19
+---------------------
+* Handle repeating industry names in algolia index and test
+
 [1.31.0] - 2022-12-06
 ---------------------
 * Added handlers for openedx-events: XBLOCK_DELETED, XBLOCK_PUBLISHED and XBLOCK_PUBLISHED.

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.31.0'
+__version__ = '1.31.1'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/algolia/serializers.py
+++ b/taxonomy/algolia/serializers.py
@@ -88,8 +88,9 @@ class JobSerializer(serializers.ModelSerializer):
         Arguments:
             obj (Job): Job instance whose industries need to be fetched.
         """
-        qs = IndustryJobSkill.objects.filter(job=obj).select_related('industry')
-        return [industry_job_skill.industry.name for industry_job_skill in qs]
+        return list(IndustryJobSkill.objects.filter(job=obj)
+                    .order_by("industry__name")
+                    .values_list('industry__name', flat=True).distinct())
 
 
 class JobSkillSerializer(serializers.ModelSerializer):

--- a/tests/algolia/test_utils.py
+++ b/tests/algolia/test_utils.py
@@ -45,6 +45,36 @@ class TestUtils(TaxonomyTestCase):
 
         assert all('industry_names' in job_data for job_data in jobs_data)
 
+    @mock.patch('taxonomy.algolia.utils.JOBS_PAGE_SIZE', 5)
+    def test_fetch_industry_job_skill_data(self):
+        """
+        Test test_fetch_industry_job_skill_data returns data for available jobs with unique industry names
+        """
+        industry_1 = factories.IndustryFactory(code=12, name='mining')
+        skill_1 = factories.SkillFactory(external_id='SKILL-1', name='skill_1')
+        skill_2 = factories.SkillFactory(external_id='SKILL-2', name='skill_2')
+        job_1 = factories.JobFactory(
+            external_id='JOB-test1',
+            name='test1'
+        )
+        factories.IndustryJobSkillFactory(
+            industry=industry_1,
+            skill=skill_1, job=job_1,
+            significance=1,
+            unique_postings=12121)
+        factories.IndustryJobSkillFactory(
+            industry=industry_1,
+            skill=skill_2,
+            job=job_1,
+            significance=2,
+            unique_postings=12131
+        )
+
+        jobs_data = fetch_jobs_data()
+
+        # Assert industrie_names are unique
+        assert all(len(set(job_data['industry_names'])) == len(job_data['industry_names']) for job_data in jobs_data)
+
     @mock.patch('taxonomy.algolia.utils.JOBS_PAGE_SIZE', 5)  # this is done to trigger the pagination flow.
     @mock.patch('taxonomy.algolia.client.algoliasearch.Client')
     def test_index_jobs_data_in_algolia(self, algolia_search_client_mock):


### PR DESCRIPTION
**Description:**
Same industry name seems to be repeated multiple times for a job. This issue was introduced when the industry data was indexed in Algolia for the first time and have been like this ever since. 
![image](https://user-images.githubusercontent.com/86868918/208420746-b1cae78f-2dd7-45e2-964c-85ccc355a32c.png)

**Solution**
Update the query of fetching industry_names from DB in serializer and write a test case of it.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [ ] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.