### PR TITLE
feat: xblock verification event handler

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 
+[1.36.0] - 2023-02-20
+---------------------
+* Added handler for openedx-events: XBLOCK_SKILL_VERIFIED.
+
 [1.35.1] - 2023-02-10
 ---------------------
 * Enabled ordering in SkillsQuizViewSet.

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,11 +6,11 @@
 #
 certifi==2022.12.7
     # via requests
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==7.0.4
+coverage==7.1.0
     # via codecov
 distlib==0.3.6
     # via virtualenv
@@ -22,13 +22,13 @@ idna==3.4
     # via requests
 packaging==23.0
     # via tox
-platformdirs==2.6.2
+platformdirs==3.0.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.1
+requests==2.28.2
     # via codecov
 six==1.16.0
     # via tox
@@ -41,7 +41,7 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.13
+urllib3==1.26.14
     # via requests
-virtualenv==20.17.1
+virtualenv==20.19.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -25,22 +25,22 @@ attrs==22.2.0
     #   -r requirements/test.txt
     #   openedx-events
     #   pytest
-beautifulsoup4==4.11.1
+beautifulsoup4==4.11.2
     # via -r requirements/test.txt
 billiard==3.6.4.0
     # via
     #   -r requirements/test.txt
     #   celery
-boto3==1.26.46
+boto3==1.26.74
     # via
     #   -r requirements/test.txt
     #   django-ses
-botocore==1.29.46
+botocore==1.29.74
     # via
     #   -r requirements/test.txt
     #   boto3
     #   s3transfer
-build==0.9.0
+build==0.10.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
@@ -59,7 +59,7 @@ cffi==1.15.1
     #   pynacl
 chardet==5.1.0
     # via diff-cover
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -79,7 +79,7 @@ code-annotations==1.3.0
     # via -r requirements/test.txt
 codecov==2.1.12
     # via -r requirements/ci.txt
-coverage[toml]==7.0.4
+coverage[toml]==7.1.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -87,13 +87,13 @@ coverage[toml]==7.0.4
     #   pytest-cov
 ddt==1.6.0
     # via -r requirements/test.txt
-diff-cover==7.3.0
+diff-cover==7.4.0
     # via -r requirements/dev.in
 distlib==0.3.6
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==3.2.16
+django==3.2.18
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
@@ -149,11 +149,11 @@ exceptiongroup==1.1.0
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==16.1.0
+faker==17.0.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
-fastavro==1.7.0
+fastavro==1.7.1
     # via
     #   -r requirements/test.txt
     #   openedx-events
@@ -191,7 +191,7 @@ kombu==4.6.11
     #   celery
 lazy-object-proxy==1.4.3
     # via astroid
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via
     #   -r requirements/test.txt
     #   jinja2
@@ -199,15 +199,15 @@ mccabe==0.6.1
     # via pylint
 mock==5.0.1
     # via -r requirements/test.txt
-newrelic==8.5.0
+newrelic==8.7.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-numpy==1.24.1
+numpy==1.24.2
     # via
     #   -r requirements/test.txt
     #   pandas
-openedx-events==4.1.0
+openedx-events==5.1.0
     # via -r requirements/test.txt
 packaging==23.0
     # via
@@ -217,23 +217,19 @@ packaging==23.0
     #   build
     #   pytest
     #   tox
-pandas==1.5.2
+pandas==1.5.3
     # via -r requirements/test.txt
 path==13.1.0
     # via
     #   -c requirements/constraints.txt
     #   edx-i18n-tools
-pbr==5.11.0
+pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-pep517==0.13.0
-    # via
-    #   -r requirements/pip-tools.txt
-    #   build
-pip-tools==6.12.1
+pip-tools==6.12.2
     # via -r requirements/pip-tools.txt
-platformdirs==2.6.2
+platformdirs==3.0.0
     # via
     #   -r requirements/ci.txt
     #   virtualenv
@@ -260,7 +256,7 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pydocstyle==6.2.3
+pydocstyle==6.3.0
     # via -r requirements/dev.in
 pygments==2.14.0
     # via diff-cover
@@ -290,7 +286,11 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pytest==7.2.0
+pyproject-hooks==1.0.0
+    # via
+    #   -r requirements/pip-tools.txt
+    #   build
+pytest==7.2.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -305,11 +305,11 @@ python-dateutil==2.8.2
     #   botocore
     #   faker
     #   pandas
-python-slugify==7.0.0
+python-slugify==8.0.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
-pytz==2022.7
+pytz==2022.7.1
     # via
     #   -r requirements/test.txt
     #   celery
@@ -322,7 +322,7 @@ pyyaml==6.0
     #   -r requirements/test.txt
     #   code-annotations
     #   edx-i18n-tools
-requests==2.28.1
+requests==2.28.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -352,7 +352,7 @@ slumber==0.7.1
     #   edx-rest-api-client
 snowballstemmer==2.2.0
     # via pydocstyle
-soupsieve==2.3.2.post1
+soupsieve==2.4
     # via
     #   -r requirements/test.txt
     #   beautifulsoup4
@@ -360,13 +360,13 @@ sqlparse==0.4.3
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==4.1.1
+stevedore==5.0.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-testfixtures==7.0.4
+testfixtures==7.1.0
     # via -r requirements/test.txt
 text-unidecode==1.3
     # via
@@ -383,7 +383,7 @@ tomli==2.0.1
     #   -r requirements/test.txt
     #   build
     #   coverage
-    #   pep517
+    #   pyproject-hooks
     #   pytest
     #   tox
 tox==3.28.0
@@ -395,11 +395,11 @@ tox-battery==0.6.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/dev.in
-types-toml==0.10.8.1
+types-toml==0.10.8.4
     # via
     #   -r requirements/test.txt
     #   responses
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
@@ -411,7 +411,7 @@ vine==1.3.0
     #   -r requirements/test.txt
     #   amqp
     #   celery
-virtualenv==20.17.1
+virtualenv==20.19.0
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,20 +4,18 @@
 #
 #    make upgrade
 #
-build==0.9.0
+build==0.10.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
 packaging==23.0
     # via build
-pep517==0.13.0
-    # via build
-pip-tools==6.12.1
+pip-tools==6.12.2
     # via -r requirements/pip-tools.in
+pyproject-hooks==1.0.0
+    # via build
 tomli==2.0.1
-    # via
-    #   build
-    #   pep517
+    # via build
 wheel==0.38.4
     # via pip-tools
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
-pip==22.3.1
+pip==23.0.1
     # via -r requirements/pip.in
-setuptools==65.6.3
+setuptools==67.3.2
     # via -r requirements/pip.in
 wheel==0.38.4
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,13 +16,13 @@ attrs==22.2.0
     # via
     #   openedx-events
     #   pytest
-beautifulsoup4==4.11.1
+beautifulsoup4==4.11.2
     # via -r requirements/base.in
 billiard==3.6.4.0
     # via celery
-boto3==1.26.46
+boto3==1.26.74
     # via django-ses
-botocore==1.29.46
+botocore==1.29.74
     # via
     #   boto3
     #   s3transfer
@@ -34,7 +34,7 @@ certifi==2022.12.7
     # via requests
 cffi==1.15.1
     # via pynacl
-charset-normalizer==2.1.1
+charset-normalizer==3.0.1
     # via requests
 click==8.1.3
     # via
@@ -42,7 +42,7 @@ click==8.1.3
     #   edx-django-utils
 code-annotations==1.3.0
     # via -r requirements/test.in
-coverage[toml]==7.0.4
+coverage[toml]==7.1.0
     # via pytest-cov
 ddt==1.6.0
     # via -r requirements/test.in
@@ -88,11 +88,11 @@ exceptiongroup==1.1.0
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==16.1.0
+faker==17.0.0
     # via
     #   -r requirements/test.in
     #   factory-boy
-fastavro==1.7.0
+fastavro==1.7.1
     # via openedx-events
 idna==3.4
     # via requests
@@ -106,21 +106,21 @@ jmespath==1.0.1
     #   botocore
 kombu==4.6.11
     # via celery
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via jinja2
 mock==5.0.1
     # via -r requirements/test.in
-newrelic==8.5.0
+newrelic==8.7.0
     # via edx-django-utils
-numpy==1.24.1
+numpy==1.24.2
     # via pandas
-openedx-events==4.1.0
+openedx-events==5.1.0
     # via -r requirements/base.in
 packaging==23.0
     # via pytest
-pandas==1.5.2
+pandas==1.5.3
     # via -r requirements/base.in
-pbr==5.11.0
+pbr==5.11.1
     # via stevedore
 pluggy==1.0.0
     # via pytest
@@ -134,7 +134,7 @@ pymongo==3.13.0
     # via edx-opaque-keys
 pynacl==1.5.0
     # via edx-django-utils
-pytest==7.2.0
+pytest==7.2.1
     # via
     #   pytest-cov
     #   pytest-django
@@ -147,9 +147,9 @@ python-dateutil==2.8.2
     #   botocore
     #   faker
     #   pandas
-python-slugify==7.0.0
+python-slugify==8.0.0
     # via code-annotations
-pytz==2022.7
+pytz==2022.7.1
     # via
     #   -r requirements/base.in
     #   celery
@@ -159,7 +159,7 @@ pytz==2022.7
     #   pandas
 pyyaml==6.0
     # via code-annotations
-requests==2.28.1
+requests==2.28.2
     # via
     #   algoliasearch
     #   edx-rest-api-client
@@ -175,16 +175,16 @@ six==1.16.0
     #   python-dateutil
 slumber==0.7.1
     # via edx-rest-api-client
-soupsieve==2.3.2.post1
+soupsieve==2.4
     # via beautifulsoup4
 sqlparse==0.4.3
     # via django
-stevedore==4.1.1
+stevedore==5.0.0
     # via
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-testfixtures==7.0.4
+testfixtures==7.1.0
     # via -r requirements/test.in
 text-unidecode==1.3
     # via python-slugify
@@ -194,9 +194,9 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-types-toml==0.10.8.1
+types-toml==0.10.8.4
     # via responses
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   botocore
     #   requests

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.35.1'
+__version__ = '1.36.0'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/signals/handlers.py
+++ b/taxonomy/signals/handlers.py
@@ -7,13 +7,16 @@ import logging
 from django.dispatch import receiver
 from openedx_events.content_authoring.data import DuplicatedXBlockData, XBlockData
 from openedx_events.content_authoring.signals import XBLOCK_DELETED, XBLOCK_DUPLICATED, XBLOCK_PUBLISHED
+from openedx_events.learning.data import XBlockSkillVerificationData
+from openedx_events.learning.signals import XBLOCK_SKILL_VERIFIED
 
 from taxonomy.tasks import (
     delete_xblock_skills,
     duplicate_xblock_skills,
     update_course_skills,
     update_program_skills,
-    update_xblock_skills
+    update_xblock_skills,
+    update_xblock_skills_verification_counts
 )
 
 from .signals import UPDATE_COURSE_SKILLS, UPDATE_PROGRAM_SKILLS, UPDATE_XBLOCK_SKILLS
@@ -45,11 +48,11 @@ def handle_update_xblock_skills(sender, xblock_uuid, **kwargs):  # pylint: disab
     Handle signal and trigger task to update xblock skills.
     """
     LOGGER.info('[TAXONOMY] UPDATE_XBLOCK_SKILLS signal received')
-    update_xblock_skills.delay([xblock_uuid])
+    update_xblock_skills.delay([str(xblock_uuid)])
 
 
 @receiver(XBLOCK_DELETED)
-def handle_xblock_deleted(**kwargs):  # pylint: disable=unused-argument
+def handle_xblock_deleted(**kwargs):
     """
     Handle signal and trigger task to delete xblock skills.
     """
@@ -58,11 +61,11 @@ def handle_xblock_deleted(**kwargs):  # pylint: disable=unused-argument
     if not xblock_data or not isinstance(xblock_data, XBlockData):
         LOGGER.error('[TAXONOMY] Received null or incorrect data from XBLOCK_DELETED.')
         return
-    delete_xblock_skills.delay([xblock_data.usage_key])
+    delete_xblock_skills.delay([str(xblock_data.usage_key)])
 
 
 @receiver(XBLOCK_DUPLICATED)
-def handle_xblock_duplicated(**kwargs):  # pylint: disable=unused-argument
+def handle_xblock_duplicated(**kwargs):
     """
     Handle signal and trigger task to duplicate xblock skills.
     """
@@ -71,11 +74,11 @@ def handle_xblock_duplicated(**kwargs):  # pylint: disable=unused-argument
     if not xblock_data or not isinstance(xblock_data, DuplicatedXBlockData):
         LOGGER.error('[TAXONOMY] Received null or incorrect data from XBLOCK_DUPLICATED.')
         return
-    duplicate_xblock_skills.delay(xblock_data.source_usage_key, xblock_data.usage_key)
+    duplicate_xblock_skills.delay(str(xblock_data.source_usage_key), str(xblock_data.usage_key))
 
 
 @receiver(XBLOCK_PUBLISHED)
-def handle_xblock_published(**kwargs):  # pylint: disable=unused-argument
+def handle_xblock_published(**kwargs):
     """
     Handle signal and trigger task to update xblock skills.
     """
@@ -84,4 +87,24 @@ def handle_xblock_published(**kwargs):  # pylint: disable=unused-argument
     if not xblock_data or not isinstance(xblock_data, XBlockData):
         LOGGER.error('[TAXONOMY] Received null or incorrect data from XBLOCK_PUBLISHED.')
         return
-    update_xblock_skills.delay([xblock_data.usage_key])
+    update_xblock_skills.delay([str(xblock_data.usage_key)])
+
+
+@receiver(XBLOCK_SKILL_VERIFIED)
+def handle_xblock_verified(**kwargs):
+    """
+    Handle signal and trigger task to update xblock skills verified and ignored count.
+    """
+    LOGGER.info('[TAXONOMY] XBLOCK_SKILL_VERIFIED signal received')
+    xblock_data = kwargs.get('xblock_info', None)
+    if not xblock_data or not isinstance(xblock_data, XBlockSkillVerificationData):
+        LOGGER.error('[TAXONOMY] Received null or incorrect data from XBLOCK_SKILL_VERIFIED.')
+        return
+    if not xblock_data.verified_skills and not xblock_data.ignored_skills:
+        LOGGER.error('[TAXONOMY] Missing verified and ignored skills list.')
+        return
+    update_xblock_skills_verification_counts.delay(
+        str(xblock_data.usage_key),
+        xblock_data.verified_skills,
+        xblock_data.ignored_skills,
+    )

--- a/taxonomy/tasks.py
+++ b/taxonomy/tasks.py
@@ -90,3 +90,18 @@ def duplicate_xblock_skills(source_xblock_uuid, xblock_uuid):
     """
     LOGGER.info('[TAXONOMY] duplicate_xblock_skills task triggered')
     utils.duplicate_xblock_skills(source_xblock_uuid, xblock_uuid)
+
+
+@shared_task()
+def update_xblock_skills_verification_counts(xblock_uuid, verified_skills, ignored_skills):
+    """
+    Task to update xblock skills verification counts.
+
+    Arguments:
+        xblock_uuid (str): uuid of xblock.
+        verified_skills (List[int]): list of verified skill ids.
+        ignored_skills (List[int]): list of ignored skill ids.
+    """
+    LOGGER.info('[TAXONOMY] update_xblock_skills_verification_counts task triggered')
+    utils.update_xblock_skills_verification_counts(xblock_uuid, verified_skills, ignored_skills)
+    LOGGER.info('[TAXONOMY] update_xblock_skills_verification_counts task completed')


### PR DESCRIPTION
**Description**

Adds handler to take `XBLOCK_SKILL_VERIFIED` signal from openedx-events implemented in https://github.com/open-craft/openedx-events/pull/1 and updates counts of related xblock skills.

**Related MRs**

- https://github.com/openedx/openedx-events/pull/165
- https://github.com/open-craft/xblock-skill-tagging/pull/1

**Test instructions**

- Checkout this branch. (No need for devstack, this can be tested independently)
- Create a virtual environment with python 3.8 and activate it.
- Run `make requirements` and `python manage.py migrate`.
- Open django shell using `python manage.py shell`.
- Run below piece of code
```python
# fill dummy data
import factory
import factory.fuzzy
from taxonomy import models
from test_utils.factories import *
XBlockSkillsFactory.create_batch(5)
SkillFactory.create_batch(20)
XBlockSkillDataFactory.create_batch(20, skill=factory.Iterator(models.Skill.objects.all()), xblock=factory.Iterator(models.XBlockSkills.objects.all()), verified=factory.fuzzy.FuzzyChoice([True, False]))
# get first xblock
xblock=XBlockSkills.objects.first()
skills = XBlockSkillData.objects.filter(xblock=xblock).values("id", "verified_count", "ignored_count")
# check that all counts are 0
print(skills)
# fire event
from openedx_events.learning.data import XBlockSkillVerificationData
from openedx_events.learning.signals import XBLOCK_SKILL_VERIFIED
XBLOCK_SKILL_VERIFIED.send_event(
    xblock_info=XBlockSkillVerificationData(
        usage_key=xblock.usage_key,
        verified_skills=[skills[0]["id"], skills[1]["id"]],
        ignored_skills=[skills[2]["id"], skills[3]["id"]],
    )
)
# verify that counts are increament
skills = XBlockSkillData.objects.filter(xblock=xblock).values("id", "verified_count", "ignored_count")
print(skills)
```

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [x] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.
