### PR TITLE
fix: Do not create a job if all of the releated skills does not exist in database

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 
+[1.36.3] - 2023-03-29
+---------------------
+* fix: Do not create a job if all of the releated skills does not exist in database
+
 [1.36.2] - 2023-03-08
 ---------------------
 * fix: remove validations on skills in skill quiz

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.36.2'
+__version__ = '1.36.3'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/management/commands/refresh_job_skills.py
+++ b/taxonomy/management/commands/refresh_job_skills.py
@@ -33,8 +33,14 @@ class Command(BaseCommand):
         Persist the jobs data in the database.
         """
         job_id = job_bucket['name']
-        job, _ = Job.objects.get_or_create(external_id=job_id)
         skill_buckets = job_bucket['ranking']['buckets']
+        skill_external_ids = [skill_bucket['name'] for skill_bucket in skill_buckets]
+
+        # If not a single skill exists then it doesn't make sense to create a job so return
+        if not Skill.objects.filter(external_id__in=skill_external_ids).exists():
+            return
+
+        job, _ = Job.objects.get_or_create(external_id=job_id)
         for skill_bucket in skill_buckets:
             skill_id = skill_bucket['name']
             try:


### PR DESCRIPTION
JIRA: https://2u-internal.atlassian.net/browse/ENT-6919

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [ ] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.