### PR TITLE
ENT-6975: Added the ability to remove unused jobs from django admin.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 
+[1.37.0] - 2023-03-31
+---------------------
+* Added the ability to remove unused jobs from django admin.
+
 [1.36.3] - 2023-03-29
 ---------------------
 * fix: Do not create a job if all of the releated skills does not exist in database

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.36.3'
+__version__ = '1.37.0'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/admin.py
+++ b/taxonomy/admin.py
@@ -7,6 +7,7 @@ Only the models that have administration requirements are exposed via the django
 from __future__ import unicode_literals
 
 from django.contrib import admin
+from django.contrib import messages
 
 from taxonomy.models import (
     CourseSkills, Job, JobPostings, JobSkills, ProgramSkill, Skill, Translation, SkillCategory,
@@ -82,6 +83,16 @@ class JobAdmin(admin.ModelAdmin):
 
     list_display = ('id', 'name', 'created', 'modified')
     search_fields = ('name',)
+    actions = ['remove_unused_jobs']
+
+    def remove_unused_jobs(self, request, queryset):  # pylint: disable=unused-argument
+        """
+        Add an action to remove unused jobs from the database.
+        """
+        delete_count, _ = Job.objects.filter(jobskills__isnull=True).delete()
+        messages.info(request, f'Successfully Deleted {delete_count} jobs.')
+
+    remove_unused_jobs.short_description = 'Remove Jobs that are not used anywhere'
 
 
 @admin.register(JobSkills)


### PR DESCRIPTION
__Jira Ticket:__ [ENT-6975](https://2u-internal.atlassian.net/browse/ENT-6975)

__Description:__
1. Delete job records that have no job skills.
2. Impact: clean the db after the bug fixed in the prior sprint, no jobs showing up in Skills Builder / other experiences that don’t have a job-skill relationships.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [x] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.