### PR TITLE
feat: making sub_category skills to job specific in career tab

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 
+[1.37.1] - 2023-03-31
+---------------------
+* feat: making sub_category skills to job specific in career tab.
+
 [1.37.0] - 2023-03-31
 ---------------------
 * Added the ability to remove unused jobs from django admin.

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.37.0'
+__version__ = '1.37.1'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/api/v1/views.py
+++ b/taxonomy/api/v1/views.py
@@ -147,7 +147,12 @@ class JobTopSkillCategoriesAPIView(APIView):
             ),
             Prefetch(
                 'skillsubcategory_set',
-                queryset=SkillSubCategory.objects.filter(skills__jobskills__job=job).distinct().prefetch_related('skill_set')
+                queryset=SkillSubCategory.objects.filter(skills__jobskills__job=job).distinct().prefetch_related(
+                    Prefetch(
+                        'skill_set',
+                        queryset=Skill.objects.filter(jobskills__job=job).distinct()
+                    )
+                )
             ),
         ).annotate(
             total_significance=Sum('skills__jobskills__significance'),

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -358,9 +358,12 @@ class TestJobTopSkillCategoriesAPIView(TestCase):
         assert len(response_subcategories) == len(expected_subcategories_ids)
         assert sorted(response_subcategories) == sorted(expected_subcategories_ids)
 
-        # assert 'skills_subcategories' skills, these skills should not just job specific instead all sub-cat skills
+        # assert 'skills_subcategories' skills, these skills should be just job specific
         for sub_category in category_data['skills_subcategories']:
-            expected_skills = list(Skill.objects.filter(subcategory_id=sub_category['id']).values_list('id', flat=True))
+            expected_skills = list(Skill.objects.filter(
+                subcategory_id=sub_category['id'],
+                jobskills__job=job,
+            ).values_list('id', flat=True))
             response_skills = [skill['id'] for skill in sub_category['skills']]
             assert len(response_skills) == len(expected_skills)
             assert sorted(response_skills) == sorted(expected_skills)
@@ -399,10 +402,10 @@ class TestJobTopSkillCategoriesAPIView(TestCase):
                 last_category_stats = this_stats
                 continue
             assert (this_stats['total_significance'] < last_category_stats['total_significance']) \
-                   or (this_stats['total_significance'] == last_category_stats['total_significance']
-                       and this_stats['total_unique_postings'] < last_category_stats['total_unique_postings']) \
-                   or (this_stats['total_unique_postings'] == last_category_stats['total_unique_postings']
-                       and this_stats['total_skills'] <= last_category_stats['total_skills'])
+                or (this_stats['total_significance'] == last_category_stats['total_significance']
+                    and this_stats['total_unique_postings'] < last_category_stats['total_unique_postings']) \
+                or (this_stats['total_unique_postings'] == last_category_stats['total_unique_postings']
+                    and this_stats['total_skills'] <= last_category_stats['total_skills'])
 
         # assert every category data individually
         for index in range(5):


### PR DESCRIPTION
***Description***
** Previous Implementation ***,
 we are getting `sub_categories` where at least one skill is related to `current_job` in `jobSkills`. In this way, the `sub_categories` that we obtain also contain other skills that are not even related to the `current_job`.

***Current Implementation***
I filtering the skills in a `sub_category` that is only directly related to the `current_job`. In this way, the number of skills that are shown in a `sub_category` in the chart will become fewer and more relevant as compared to the previous approach, and this will reduce the false positive effect.

[JIRA ENT-6976](https://2u-internal.atlassian.net/browse/ENT-6976)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [ ] [Version](https://github.com/edx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/edx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.