### PR TITLE
build: remove unnecessary codecov dependency & upgrade GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Run Coverage
       if: matrix.python-version == '3.8' && matrix.toxenv=='django32'
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         flags: unittests
         fail_ci_if_error: true

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -2,6 +2,5 @@
 
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
 tox-battery==0.6.1        # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,8 +8,6 @@ certifi==2022.12.7
     # via requests
 charset-normalizer==3.0.1
     # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
 coverage==7.1.0
     # via codecov
 distlib==0.3.6

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -77,8 +77,6 @@ click-log==0.3.2
     # via edx-lint
 code-annotations==1.3.0
     # via -r requirements/test.txt
-codecov==2.1.12
-    # via -r requirements/ci.txt
 coverage[toml]==7.1.0
     # via
     #   -r requirements/ci.txt


### PR DESCRIPTION
Context: https://about.codecov.io/blog/message-regarding-the-pypi-package/
**Merge checklist:**
- ❌ (won't do) Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements