### PR TITLE
feat: add 'b2c_opt_in' attribute to job serializer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
   deprecated.  See https://github.com/openedx/edx-sphinx-theme/issues/184 for
   more details.
 
+[1.38.0] - 2023-05-03
+---------------------
+* feat: Added a new attribute (`b2c_opt_in`) to the JobSerializer
+
 [1.37.3] - 2023-05-03
 ---------------------
 * feat: generate job description only if job has name and description is empty

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.37.3'
+__version__ = '1.38.0'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
[APER-2377]

I am requesting an update to the data provided by the JobSerializer. We would like to limit the job options a learner can select from using the B2C version of the Skills Builder. To do this, we need an attribute in the data pushed to Algolia that we can filter on.

To do this, we have added a new derived field to the JobSerializer. It will check a new setting (`TAXONOMY_B2C_JOB_ALLOWLIST`) which is a (string) list of job ids (the lightcast `external_id`). If the external ID of a job matches an item on the list, it is "allowlisted" and can be displayed as an option to the B2C learners.

I don't think this change should affect existing consumers of this Algolia index.

Thanks for your consideration!

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [x] [Version](https://github.com/openedx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/openedx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.