### PR TITLE
fix: generate job description only if job has name and description is empty

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
   deprecated.  See https://github.com/openedx/edx-sphinx-theme/issues/184 for
   more details.
 
+[1.37.3] - 2023-05-03
+---------------------
+* feat: generate job description only if job has name and description is empty
+
 [1.37.2] - 2023-04-27
 ---------------------
 * feat: Generate ai based job descriptions

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.37.2'
+__version__ = '1.37.3'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/management/commands/generate_job_descriptions.py
+++ b/taxonomy/management/commands/generate_job_descriptions.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
         LOGGER.info('Command started. Generating job descriptions for all jobs.')
 
         with ThreadPoolExecutor(max_workers=40) as executor:
-            for job in Job.objects.filter(description=''):
+            for job in Job.objects.exclude(name__isnull=True).filter(description=''):
                 executor.submit(generate_and_store_job_description, job.external_id, job.name)
 
         LOGGER.info('Command completed. Successfully generated job descriptions for all jobs.')

--- a/taxonomy/signals/handlers.py
+++ b/taxonomy/signals/handlers.py
@@ -120,5 +120,6 @@ def handle_generate_job_description(sender, instance, created, **kwargs):  # pyl
     Handler for post_save signal for Job model.
     """
     LOGGER.info('[TAXONOMY] Job post_save signal received. Job: [%s]', instance.name)
-    if created:
+    # Trigger celery task only if job name exists and description is missing
+    if instance.name and not instance.description:
         generate_job_description.delay(instance.external_id, instance.name)

--- a/tests/management/test_generate_job_descriptions.py
+++ b/tests/management/test_generate_job_descriptions.py
@@ -59,3 +59,12 @@ class TestGenerateJobDescriptions(TransactionTestCase):
 
         job = Job.objects.get(external_id=existing_job.external_id)
         assert job.description == existing_job.description
+
+    @mock.patch('taxonomy.management.commands.generate_job_descriptions.generate_and_store_job_description')  # pylint: disable=invalid-name
+    def test_command_with_job_without_name(self, mocked_generate_and_store_job_description):
+        """
+        Test `generate_job_descriptions` management command works correctly if job has no name.
+        """
+        Job(external_id='11111').save()
+        call_command(self.command)
+        mocked_generate_and_store_job_description.assert_not_called()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -388,6 +388,24 @@ class TestJob(TestCase):
             mocked_generate_and_store_job_description.assert_any_call(job.external_id, job.name)
             mocked_chat_completion.assert_any_call(prompt)
 
+    @pytest.mark.use_signals
+    @patch('taxonomy.signals.handlers.generate_job_description.delay')
+    def test_task_triggered_only_if_job_has_name(self, mocked_generate_job_description_task):
+        """
+        Verify that celery task triggers only when a job has name.
+        """
+        Job(external_id='11111').save()
+        mocked_generate_job_description_task.assert_not_called()
+
+    @pytest.mark.use_signals
+    @patch('taxonomy.signals.handlers.generate_job_description.delay')
+    def test_task_does_not_triggered_if_job_has_description(self, mocked_generate_job_description_task):
+        """
+        Verify that celery task does not triggered when a job already has description.
+        """
+        Job(external_id='11111', name='job name', description='I am description').save()
+        mocked_generate_job_description_task.assert_not_called()
+
 
 @mark.django_db
 class TestJobPath(TestCase):


### PR DESCRIPTION
**Description:** Generate job description only if a job has a name and its description is empty.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [ ] [Version](https://github.com/openedx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/openedx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.