### PR TITLE
feat: LearnersCurrentJobAPIView to fetch current job of learners in LMS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 
+[1.40.0] - 2023-06-02
+---------------------
+* feat: Added JobHolderUsernamesAPIView to fetch current job of learners by LMS.
+
 [1.39.0] - 2023-05-09
 ---------------------
 * feat: Added CourseRunMetadataProvider to fetch course run info.

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.39.0'
+__version__ = '1.40.0'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/api/v1/urls.py
+++ b/taxonomy/api/v1/urls.py
@@ -11,6 +11,7 @@ from taxonomy.api.v1.views import (
     JobPostingsViewSet,
     JobsViewSet,
     JobTopSkillCategoriesAPIView,
+    LearnersCurrentJobAPIView,
     SkillsQuizViewSet,
     SkillViewSet,
     XBlockSkillsViewSet,
@@ -22,6 +23,7 @@ urlpatterns = [
     path(r'job-top-subcategories/<int:job_id>/', JobTopSkillCategoriesAPIView.as_view(), name='job_top_subcategories'),
     path(r'job-holder-usernames/<int:job_id>/', JobHolderUsernamesAPIView.as_view(), name='job_holder_usernames'),
     path(r'job-path/', JobPathAPIView.as_view(), name='job_path'),
+    path(r'learners-current-job/', LearnersCurrentJobAPIView.as_view(), name='learners_current_job'),
 ]
 
 ROUTER.register(r'skills', SkillViewSet, basename='skill')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -416,6 +416,55 @@ class TestJobTopSkillCategoriesAPIView(TestCase):
 
 
 @mark.django_db
+class TestLearnersCurrentJobAPIView(TestCase):
+    """
+    Tests for `LearnersCurrentJobAPIView` API view.
+    """
+
+    def setUp(self) -> None:
+        """
+        Setup env.
+        """
+        super(TestLearnersCurrentJobAPIView, self).setUp()
+        self.user = User.objects.create(username="rocky", is_staff=True)
+        self.user.set_password(USER_PASSWORD)
+        self.user.save()
+        self.client = Client()
+        self.client.login(username=self.user.username, password=USER_PASSWORD)
+        self.job = JobFactory()
+
+        self.view_url = reverse('learners_current_job')
+
+    def test_unauthenticated_user_failure(self):
+        """
+        Test that non-staff user should not access this API.
+        """
+        client = Client()
+        api_response = client.get(self.view_url)
+        assert api_response.status_code == 403
+
+    def test_success(self):
+        """
+        Test success response for the API.
+        """
+        SkillsQuizFactory(username="user1")
+        SkillsQuizFactory(username="user1")
+        SkillsQuizFactory(username="user2")
+        SkillsQuizFactory(username="user2")
+        SkillsQuizFactory(username="user3")
+
+        with self.assertNumQueries(3):
+            api_response = self.client.get(self.view_url)
+
+        # assert that we get status code 200
+        assert api_response.status_code == 200
+        data = api_response.json()
+
+        # assert that usernames list has size of 100
+        assert len(data) == 3
+
+
+@mark.django_db
 class TestJobHolderUsernamesAPIView(TestCase):
     """
     Tests for `JobHolderUsernamesAPIView` API view.


### PR DESCRIPTION
**Description**
<img width="1614" alt="Screenshot 2023-06-02 at 4 13 01 PM" src="https://github.com/openedx/taxonomy-connector/assets/106396899/6c4f5f08-7909-4183-8738-2b48d3d1bf12">

JIRA: [ENT-7192](https://2u-internal.atlassian.net/browse/ENT-7192)

**Context**
Previously, created this draft PR https://github.com/openedx/taxonomy-connector/pull/160 containing a management command which updates the current job of learners in extended profile of learners in LMS. During testing of this management command, found out that only the learner themselves are allowed to edit their extended profile. This check is implemented by matching the username of user calling the API with the username in user profile. This makes user privileges irrelevant. Now, I have changed the approach. Moved the database query in this API to fetch current_job data of learners and writing a management command in LMS to use this endpoint. 

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [x] [Version](https://github.com/openedx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/openedx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.