### PR TITLE
feat: reuse tags from similar product

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,12 @@ Change Log
 
 Unreleased
 
+[1.43.0] - 2023-07-07
+---------------------
+* feat: reuse tags from similar product for xblock skills.
+* fix: remove duplicates from xblocks skills api.
+* refactor: update logic to mark course run complete in refresh_xblock_skills command.
+
 [1.42.3] - 2023-07-14
 ---------------------
 * perf: memory optimisation for job recommendations.

--- a/taxonomy/api/filters.py
+++ b/taxonomy/api/filters.py
@@ -55,5 +55,5 @@ class XBlocksFilter(filters.FilterSet):
                 queryset=Skill.objects.filter(
                     xblockskilldata__is_blacklisted=False,
                     xblockskilldata__verified=value,
-                ),
+                ).distinct(),
             ))

--- a/taxonomy/api/v1/views.py
+++ b/taxonomy/api/v1/views.py
@@ -305,7 +305,7 @@ class XBlockSkillsViewSet(TaxonomyAPIViewSetMixin, RetrieveModelMixin, ListModel
         return XBlockSkills.objects.all().prefetch_related(
             Prefetch(
                 'skills',
-                queryset=Skill.objects.filter(xblockskilldata__is_blacklisted=False),
+                queryset=Skill.objects.filter(xblockskilldata__is_blacklisted=False).distinct(),
             ),
         )
 

--- a/taxonomy/exceptions.py
+++ b/taxonomy/exceptions.py
@@ -32,3 +32,9 @@ class InvalidCommandOptionsError(Exception):
     """
     Exception to raise when incorrect command options are provided.
     """
+
+
+class SkipProductProcessingError(Exception):
+    """
+    Exception to raise when we want to skip product processing.
+    """

--- a/taxonomy/management/commands/refresh_xblock_skills.py
+++ b/taxonomy/management/commands/refresh_xblock_skills.py
@@ -125,10 +125,11 @@ class Command(BaseCommand):
     ):
         """
         Add an entry to CourseRunXBlockSkillsTracker table marking the course
-        as complete if the ratio of success_count/total >= threshold
+        as complete if the ratio of success_count/total >= threshold.
+        Marks course complete if total == 0.
         """
         total = success_count + failure_count
-        success_ratio = success_count / total if total else 0
+        success_ratio = success_count / total if total else 1
         if success_ratio >= threshold:
             LOGGER.info(
                 '[TAXONOMY] Marking course run: [%s] as complete as success ratio: [%s] > threshold: [%s]',

--- a/taxonomy/management/commands/refresh_xblock_skills.py
+++ b/taxonomy/management/commands/refresh_xblock_skills.py
@@ -132,7 +132,7 @@ class Command(BaseCommand):
         success_ratio = success_count / total if total else 1
         if success_ratio >= threshold:
             LOGGER.info(
-                '[TAXONOMY] Marking course run: [%s] as complete as success ratio: [%s] > threshold: [%s]',
+                '[TAXONOMY] Marking course run: [%s] as complete as success ratio: [%s] >= threshold: [%s]',
                 course_run_key,
                 success_ratio,
                 threshold

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -537,10 +537,18 @@ class TestXBlockSkillsViewSet(TestCase):
             False,
             3,
             verified=False,
-            xblock=self.xblock_skills[0],
+            xblock=self.xblock_skills[1],
         ))
-        XBlockSkillDataFactory.simple_generate_batch(False, 5, xblock=self.xblock_skills[1])
         for i, xblock_skill_data in enumerate(self.xblock_skill_data_objs):
+            xblock_skill_data.skill = self.skills[i]
+            xblock_skill_data.save()
+        self.xblock_skill_data_objs.extend(XBlockSkillDataFactory.simple_generate_batch(
+            False,
+            2,
+            verified=False,
+            xblock=self.xblock_skills[2],
+        ))
+        for i, xblock_skill_data in enumerate(self.xblock_skill_data_objs[5:]):
             xblock_skill_data.skill = self.skills[i]
             xblock_skill_data.save()
         self.user = User.objects.create(username="rocky")


### PR DESCRIPTION
**Description**

Adds functionality reuse tags from another xblock if the content is same, reducing calls to external API.

This PR also updates the logic to mark a course run as processed in terms of xblock tagging as well as fixes a bug with Xblock skills API where it returns duplicate skills for an xblock.

**Setup and Test instructions**

**Setup**

* Setup latest devstack master branch locally.
* Run required services using `make {lms,studio,discovery}-up`
* Open discovery shell using `make discovery-shell`.
* Install this repo using `pip install -e /edx/src/taxonomy-connector`
* Login to discovery admin at http://localhost:18381/admin/ with edx user.
* Go to http://localhost:18381/admin/taxonomy/xblockskills/ and create an XBlockSkills entry using below details:
  ```
  Usage key: block-v1:edX+DemoX+Demo_Course+type@video+block@8d03ac3ebc934f438b40286738128fd8
  Requires verification: true
  Auto processed: true
  Hash content: f77c5ba3ec3d8fa3b724985d7a1b65f1
  ```
* Go to http://localhost:18381/admin/taxonomy/skill/ and create two-three skills with some random data.
* Go to http://localhost:18381/admin/taxonomy/xblockskilldata/ and click on `Add` button.
* Select the xblock and skill that we created in above steps to link them together.
* Create as many XBlockSkillData entries as the skills.


**Testing tags reuse functionality**

* Open discovery shell using `make discovery-shell`.
* Open django shell using `python manage.py shell`.
* Run below snippet to tag a new xblock which has similar content as the one that we added above (same hash).
```python
from taxonomy import models, utils
from taxonomy.choices import ProductTypes
xblock = {
    'key':  "block-v1:edX+DemoX+Demo_Course+type@vertical+block@867dddb6f55d410caaa9c1eb9c6743ec",
    'content_type': "vertical",
    'content': "Avoid something human whole treatment ground medical so coach wrong daughter indeed nature quickly follow use thing cultu ral vote sign for job affect enter charge where instead account resource agency important available statement."
}
success_count, failure_count = utils.refresh_product_skills([xblock], True, ProductTypes.XBlock)
```
* `refresh_product_skills` generally fetches skills from an external API which we have not setup, still the above snippet works as it is reusing skills from another XBlock.
* Go to http://localhost:18381/admin/taxonomy/xblockskilldata/ and verify that similar entries for the vertical xblock are created.

**Testing API duplicate skills bug**

* Change branch to master in taxonomy-connector repository
* Go to http://localhost:18381/taxonomy/api/v1/xblocks/
* The API will respond with duplicate skills in each xblock.
* Now change the branch to this PR and visit http://localhost:18381/taxonomy/api/v1/xblocks/ again.
* The duplicate skills issue should be resolved.

**Testing course completion logic change**

* Go to studio and create an empty course.
* Change branch to master in taxonomy-connector repository
* Open discovery-shell using `make discovery-shell` in devstack.
* Run `python manage.py refresh_xblock_skills --course <course-key> --commit` where course-key can be found by in the studio URL, for example: URL: `http://localhost:18010/course/course-v1:UNIX+CS101+2023_T1` has course-key `course-v1:UNIX+CS101+2023_T1`.
* The above command will not mark the course complete even if it doesn't have any xblocks. You can verify this by visiting http://localhost:18381/admin/taxonomy/courserunxblockskillstracker/. It will not have any entry related to this course.
* Now change the branch to this PR and run the command again.
* The course will be marked as processed.


**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [x] [Version](https://github.com/openedx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/openedx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.