### PR TITLE
fix: missing comma masking b2c_opt_in attribute

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 
+[1.43.4] - 2023-08-02
+---------------------
+* fix: Added missing comma in algolia constants that was masking the b2c_opt_in attribute.
+
 [1.43.3] - 2023-08-02
 ---------------------
 * fix: Fixed some implementation issues in job recommendation logic.

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.43.3'
+__version__ = '1.43.4'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/algolia/constants.py
+++ b/taxonomy/algolia/constants.py
@@ -16,7 +16,7 @@ ALGOLIA_JOBS_INDEX_SETTINGS = {
         'searchable(skills.name)',
         'searchable(industry_names)',
         'searchable(b2c_opt_in)',
-        'searchable(job_sources)'
+        'searchable(job_sources)',
     ],
 }
 

--- a/taxonomy/algolia/constants.py
+++ b/taxonomy/algolia/constants.py
@@ -15,7 +15,7 @@ ALGOLIA_JOBS_INDEX_SETTINGS = {
         'searchable(name)',
         'searchable(skills.name)',
         'searchable(industry_names)',
-        'searchable(b2c_opt_in)'
+        'searchable(b2c_opt_in)',
         'searchable(job_sources)'
     ],
 }


### PR DESCRIPTION
A missing comma in the Algolia constants was preventing the b2c_opt_in attribute from being used.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [x] [Version](https://github.com/openedx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/openedx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.