### PR TITLE
fix: chunked data in EMSI client for xblock-skills job

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 
+[1.44.2] - 2023-09-11
+---------------------
+* fix: chunked data at 50000 byte in EMSI client for xblock-skills job
+
 [1.44.1] - 2023-08-25
 ---------------------
 * feat: add prefetch related to the whitelisted product skills

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.44.1'
+__version__ = '1.44.2'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/emsi/client.py
+++ b/taxonomy/emsi/client.py
@@ -183,6 +183,7 @@ class EMSISkillsApiClient(JwtEMSIApiClient):
     """
 
     API_BASE_URL = urljoin(JwtEMSIApiClient.API_BASE_URL, '/skills/versions/8.9')
+    MAX_LIGHTCAST_DATA_SIZE = 50000  # Maximum 50,000-byte data is supported by LightCast
 
     def __init__(self):
         """
@@ -229,6 +230,11 @@ class EMSISkillsApiClient(JwtEMSIApiClient):
         Returns:
             dict: A dictionary containing details of all the skills.
         """
+
+        if text_data and len(text_data) > self.MAX_LIGHTCAST_DATA_SIZE:
+            # Truncate the text_data to 50,000 bytes since only 50,000-byte data is supported by LightCast
+            text_data = text_data[:self.MAX_LIGHTCAST_DATA_SIZE]
+
         data = {
             'text': text_data
         }

--- a/tests/emsi/test_client.py
+++ b/tests/emsi/test_client.py
@@ -157,7 +157,15 @@ class TestEMSISkillsApiClient(TaxonomyTestCase):
         """
         Validate that the behavior of client while fetching product skills.
         """
+
+        max_data_size = self.client.MAX_LIGHTCAST_DATA_SIZE
+        # Chunk larger-sized data according to the maximum supported size
+        truncated_text_data = (SKILL_TEXT_DATA * max_data_size)[:max_data_size]
+
         skills = self.client.get_product_skills(SKILL_TEXT_DATA)
+
+        # Validate that the larger data has been chunked according to the maximum supported size
+        assert len(truncated_text_data) == max_data_size
 
         assert skills == SKILLS_EMSI_CLIENT_RESPONSE
 

--- a/tests/emsi/test_client.py
+++ b/tests/emsi/test_client.py
@@ -5,6 +5,8 @@ Tests for the `taxonomy-connector` emsi client.
 
 import logging
 from time import time
+from unittest import mock
+from faker import Faker
 
 import responses
 from pytest import raises
@@ -157,17 +159,24 @@ class TestEMSISkillsApiClient(TaxonomyTestCase):
         """
         Validate that the behavior of client while fetching product skills.
         """
-
-        max_data_size = self.client.MAX_LIGHTCAST_DATA_SIZE
-        # Chunk larger-sized data according to the maximum supported size
-        truncated_text_data = (SKILL_TEXT_DATA * max_data_size)[:max_data_size]
-
         skills = self.client.get_product_skills(SKILL_TEXT_DATA)
 
-        # Validate that the larger data has been chunked according to the maximum supported size
-        assert len(truncated_text_data) == max_data_size
-
         assert skills == SKILLS_EMSI_CLIENT_RESPONSE
+
+    def test_get_product_skills_large_text(self):
+        """
+        Validate that the behavior of client while fetching product skills for very large text.
+        """
+        api_response = mock.Mock()
+        api_response.json.return_value = SKILLS_EMSI_RESPONSE
+        self.client.is_token_expired = mock.Mock(return_value=False)
+        self.client.client = mock.MagicMock(post=mock.Mock(return_value=api_response))
+
+        max_data_size = self.client.MAX_LIGHTCAST_DATA_SIZE
+        skill_text_data = Faker().text(max_data_size + max_data_size * 0.1)
+        self.client.get_product_skills(skill_text_data)
+
+        assert len(self.client.client.post.call_args_list[0][1]['json']['text']) == max_data_size
 
     @mock_api_response(
         method=responses.POST,


### PR DESCRIPTION
**Jira Ticket**: [ENT-7588](https://2u-internal.atlassian.net/browse/ENT-7588)

**Description**:
LightCast API was throwing errors when processing larger data sizes, handled it by adjusting data chunking to a maximum size of 50,000 bytes, aligning with LightCast's supported max data size limit.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [x] [Version](https://github.com/openedx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/openedx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.