### PR TITLE
ENT-7622: Removed direct usages objects in favour of whitelisted or blacklisted query sets.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 
+[1.46.0] - 2023-10-23
+---------------------
+* feat: Removed direct usages of JobSkills and IndustryJobSkills objects in favour of whitelisted or blacklisted query sets.
+
 [1.45.0] - 2023-10-13
 ---------------------
 * feat: Added the ability to blacklist job-skill relationship.

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.45.0'
+__version__ = '1.46.0'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/algolia/serializers.py
+++ b/taxonomy/algolia/serializers.py
@@ -73,7 +73,11 @@ class JobSerializer(serializers.ModelSerializer):
             obj (Job): Job instance whose skills need to be fetched.
         """
         # We only need to fetch up-to 20 skills per job.
-        qs = JobSkills.objects.filter(job=obj).select_related('skill')[:EMBEDDED_OBJECT_LENGTH_CAP]
+        qs = JobSkills.get_whitelisted_job_skill_qs().filter(
+            job=obj
+        ).select_related(
+            'skill'
+        )[:EMBEDDED_OBJECT_LENGTH_CAP]
         serializer = JobSkillSerializer(qs, many=True)
         return serializer.data
 
@@ -97,7 +101,7 @@ class JobSerializer(serializers.ModelSerializer):
             obj (Job): Job instance whose industries need to be fetched.
         """
         return list(
-            IndustryJobSkill.objects.filter(
+            IndustryJobSkill.get_whitelisted_job_skill_qs().filter(
                 job=obj
             ).order_by(
                 'industry__name'
@@ -114,7 +118,7 @@ class JobSerializer(serializers.ModelSerializer):
         """
         industries = []
         job_industries = list(
-            IndustryJobSkill.objects.filter(
+            IndustryJobSkill.get_whitelisted_job_skill_qs().filter(
                 job=obj
             ).order_by(
                 'industry__name'

--- a/taxonomy/algolia/utils.py
+++ b/taxonomy/algolia/utils.py
@@ -102,7 +102,7 @@ def calculate_job_skills(jobs_qs):
     job_details = {}
     for job in jobs_qs.all():
         skills = set(
-            JobSkills.objects.filter(job=job).values_list('skill__name', flat=True)
+            JobSkills.get_whitelisted_job_skill_qs().filter(job=job).values_list('skill__name', flat=True)
         )
         job_details[job.name] = {
             'skills': skills,
@@ -207,7 +207,7 @@ def combine_industry_skills():
     for industry in Industry.objects.all():
         # sum all significances for the same skill and then sort on total significance
         skills = list(
-            IndustryJobSkill.objects.filter(
+            IndustryJobSkill.get_whitelisted_job_skill_qs().filter(
                 industry=industry
             ).values_list(
                 'skill__name', flat=True
@@ -262,8 +262,8 @@ def fetch_jobs_data():
             context={
                 'jobs_data': jobs_data,
                 'industry_skills': industry_skills,
-                'jobs_having_job_skills': get_job_ids(JobSkills.objects),
-                'jobs_having_industry_skills': get_job_ids(IndustryJobSkill.objects),
+                'jobs_having_job_skills': get_job_ids(JobSkills.get_whitelisted_job_skill_qs()),
+                'jobs_having_industry_skills': get_job_ids(IndustryJobSkill.get_whitelisted_job_skill_qs()),
             },
         )
         jobs.extend(job_serializer.data)

--- a/taxonomy/api/v1/serializers.py
+++ b/taxonomy/api/v1/serializers.py
@@ -47,12 +47,21 @@ class JobSkillSerializer(ModelSerializer):
 
 
 class JobsListSerializer(ModelSerializer):
-    skills = JobSkillSerializer(source='jobskills_set.all', many=True)
+    skills = serializers.SerializerMethodField()
 
     class Meta:
         model = Job
         fields = '__all__'
         extra_fields = ('skills',)
+
+    def get_skills(self, instance):
+        """
+        Get JobSkill records.
+        """
+        return JobSkillSerializer(
+            JobSkills.get_whitelisted_job_skill_qs().filter(job=instance),
+            many=True,
+        ).data
 
 
 class CourseSkillsSerializer(ModelSerializer):

--- a/taxonomy/utils.py
+++ b/taxonomy/utils.py
@@ -492,7 +492,7 @@ def get_course_jobs(course_key, product_type=ProductTypes.Course):
         list: A list of dicts where each dict contain information about a particular job.
     """
     course_skills = get_whitelisted_product_skills(course_key, product_type)
-    job_skills = JobSkills.objects.select_related(
+    job_skills = JobSkills.get_whitelisted_job_skill_qs().select_related(
         'skill',
         'job',
         'job__jobpostings',


### PR DESCRIPTION
__Jira Ticket:__ [ENT-7622](https://2u-internal.atlassian.net/browse/ENT-7622)

__Description:__
This PR replaces all the direct usages of `JobSkills` and `IndustryJobSkill`'s `objects` with the utility methods added in `BaseJobSkill` model


**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [x] [Version](https://github.com/openedx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/openedx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.