### PR TITLE
feat: modify queryset from prefetch to select related

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ Unreleased
 
 [1.46.1] - 2024-01-05
 ---------------------
-* feat: Modify prefetch queryset to select related of whitelisted product skills.
+* feat: Modify prefetch related to select related for whitelisted product skills.
 
 [1.46.0] - 2023-10-23
 ---------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 
+[1.46.1] - 2024-01-05
+---------------------
+* feat: Modify prefetch queryset to select related of whitelisted product skills.
+
 [1.46.0] - 2023-10-23
 ---------------------
 * feat: Removed direct usages of JobSkills and IndustryJobSkills objects in favour of whitelisted or blacklisted query sets.

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.46.0'
+__version__ = '1.46.1'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/utils.py
+++ b/taxonomy/utils.py
@@ -64,7 +64,7 @@ def get_whitelisted_serialized_skills(key_or_uuid, product_type=ProductTypes.Cou
         return cached_response.value
 
     whitelisted_product_skills = get_whitelisted_product_skills(key_or_uuid, product_type)
-    product_skills = whitelisted_product_skills.prefetch_related('skill__category', 'skill__subcategory')
+    product_skills = whitelisted_product_skills.select_related('skill__category', 'skill__subcategory')
     skills = [product_skill.skill for product_skill in product_skills]
     skills_data = SkillSerializer(skills, many=True).data
     TieredCache.set_all_tiers(


### PR DESCRIPTION
[PROD-3860](https://2u-internal.atlassian.net/browse/PROD-3860)
---------
This PR modifies prefetch queryset to select_related query to reduce db round-trip for a skill fetching.

Testing:
-------
- Clone taxonomy in `edx/src` directory.
- Install taxonomy via discovery shell in editable mode
```bash
pip install -e /edx/src/taxonomy-connector
```
- Comment cache-related code to verify the impact
- Add `Course Skills` to courses via discovery admin.
- Check query count on master and ensure the response has skills information.
- Checkout `modify-queryset` and hit the endpoint again. Note the decrease in query count.

----------

- Tested `search/all` endpoint with 2 scenarios:
Course with multiple skills -> (with no skill_category and skill_subcategory)
    - with select_related: 94-96 queries
    - with prefetch_related: 93 queries
Courses with multiple skill -> (having skill_category and skill_subcategory)
    - with select_related: 106 queries.
    - with prefetch_related: 112 queries

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [ ] [Version](https://github.com/openedx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/openedx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.