### PR TITLE
feat: return no result if skill validation is disable for a course

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 
+[1.50.0] - 2024-03-21
+---------------------
+* feat: For taxonomy/api/v1/xblocks/ api, send no result if skill validation is disabled for the course.
+
 [1.46.2] - 2024-02-14
 ---------------------
 * feat: Optimized finalize_xblockskill_tags command for memory via chunking

--- a/taxonomy/__init__.py
+++ b/taxonomy/__init__.py
@@ -15,6 +15,6 @@ each course based on its description, title etc.
 # 2. MINOR version when you add functionality in a backwards compatible manner, and
 # 3. PATCH version when you make backwards compatible bug fixes.
 # More details can be found at https://semver.org/
-__version__ = '1.46.2'
+__version__ = '1.50.0'
 
 default_app_config = 'taxonomy.apps.TaxonomyConfig'  # pylint: disable=invalid-name

--- a/taxonomy/api/v1/views.py
+++ b/taxonomy/api/v1/views.py
@@ -38,6 +38,7 @@ from taxonomy.models import (
     XBlockSkillData,
     XBlockSkills,
 )
+from taxonomy.providers.utils import get_course_metadata_provider
 
 
 class TaxonomyAPIViewSetMixin:
@@ -301,7 +302,14 @@ class XBlockSkillsViewSet(TaxonomyAPIViewSetMixin, RetrieveModelMixin, ListModel
     def get_queryset(self):
         """
         Get all the xblocks skills with prefetch_related objects.
+
+        If skill validation is disabled for a course, then return an empty queryset.
         """
+        course_run_key = self.request.query_params.get('course_key')
+        skill_validation_disabled = get_course_metadata_provider().skill_validation_disabled(course_run_key)
+        if skill_validation_disabled:
+            return XBlockSkills.objects.none()
+
         return XBlockSkills.objects.prefetch_related(
             Prefetch(
                 'skills',

--- a/taxonomy/providers/course_metadata.py
+++ b/taxonomy/providers/course_metadata.py
@@ -46,3 +46,15 @@ class CourseMetadataProvider:
             4. short_description: Course's short description
             5. full_description: Course's full description
         """
+
+    @abstractmethod
+    def skill_validation_disabled(self, course_run_key) -> bool:
+        """
+        Get whether skill validation is disabled for a course.
+
+        Arguments:
+          course_run_key(str): A course run key.
+
+        Returns:
+          bool: `True` if skill validation is disabled for the course run, `False` otherwise.
+        """

--- a/taxonomy/validators/course_metadata.py
+++ b/taxonomy/validators/course_metadata.py
@@ -4,6 +4,8 @@ Validator for course metadata provider.
 
 All host platform must run this validator to make sure providers are working as expected.
 """
+import inspect
+
 from taxonomy.providers.utils import get_course_metadata_provider
 
 
@@ -32,6 +34,7 @@ class CourseMetadataProviderValidator:
         """
         self.validate_get_courses()
         self.validate_get_all_courses()
+        self.validate_skill_validation_disabled()
 
     def validate_get_courses(self):
         """
@@ -60,3 +63,11 @@ class CourseMetadataProviderValidator:
             assert 'title' in course
             assert 'short_description' in course
             assert 'full_description' in course
+
+    def validate_skill_validation_disabled(self):
+        """
+        Validate `skill_validation_disabled` methods has the correct interface implemented.
+        """
+        skill_validation_disabled_func = getattr(self.course_metadata_provider, 'skill_validation_disabled')  # pylint: disable=literal-used-as-attribute
+        assert callable(skill_validation_disabled_func)
+        assert str(inspect.signature(skill_validation_disabled_func)) == '(course_run_key) -> bool'

--- a/test_utils/providers.py
+++ b/test_utils/providers.py
@@ -95,6 +95,12 @@ class DiscoveryCourseMetadataProvider(CourseMetadataProvider):
                 'full_description': course.full_description,
             }
 
+    def skill_validation_disabled(self, course_run_key) -> bool:
+        """
+        Whether skill validation is disabled for the course.
+        """
+        return bool(course_run_key)
+
 
 class DiscoveryProgramMetadataProvider(ProgramMetadataProvider):
     """

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -617,6 +617,14 @@ class TestXBlockSkillsViewSet(TestCase):
         })
         self._verify_xblocks_data(api_response, self.xblock_skills[:1], verified=False)
 
+    def test_xblocks_api_with_skill_validation_disabled(self):
+        """
+        Verify that xblocks API return no result if skill validation is disabled for a course.
+        """
+        api_response = self.client.get(self.view_url, {"course_key": 'course-v1:edX+M12+1T2024'})
+        assert api_response.status_code == 200
+        assert api_response.json() == []
+
 
 @mark.django_db
 class TestJobPathAPIView(TestCase):


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [ ] [Version](https://github.com/openedx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/openedx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.