### PR TITLE
chore: remove unused openai pypi pkg

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -13,5 +13,4 @@ beautifulsoup4
 django-choices
 django-filter
 openedx-events
-openai
 django-object-actions

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -28,7 +28,7 @@ pluggy==1.6.0
     # via tox
 pyproject-api==1.9.1
     # via tox
-tox==4.30.2
+tox==4.30.3
     # via -r requirements/ci.in
 virtualenv==20.34.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,16 +12,7 @@ amqp==5.3.1
     # via
     #   -r requirements/test.txt
     #   kombu
-annotated-types==0.7.0
-    # via
-    #   -r requirements/test.txt
-    #   pydantic
-anyio==4.11.0
-    # via
-    #   -r requirements/test.txt
-    #   httpx
-    #   openai
-asgiref==3.9.2
+asgiref==3.10.0
     # via
     #   -r requirements/test.txt
     #   django
@@ -29,21 +20,21 @@ astroid==3.3.11
     # via
     #   pylint
     #   pylint-celery
-attrs==25.3.0
+attrs==25.4.0
     # via
     #   -r requirements/test.txt
     #   openedx-events
-beautifulsoup4==4.14.0
+beautifulsoup4==4.14.2
     # via -r requirements/test.txt
 billiard==4.2.2
     # via
     #   -r requirements/test.txt
     #   celery
-boto3==1.40.40
+boto3==1.40.46
     # via
     #   -r requirements/test.txt
     #   django-ses
-botocore==1.40.40
+botocore==1.40.46
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -58,11 +49,9 @@ cachetools==6.2.0
     #   tox
 celery==5.5.3
     # via -r requirements/test.txt
-certifi==2025.8.3
+certifi==2025.10.5
     # via
     #   -r requirements/test.txt
-    #   httpcore
-    #   httpx
     #   requests
 cffi==2.0.0
     # via
@@ -126,11 +115,7 @@ distlib==0.4.0
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-distro==1.9.0
-    # via
-    #   -r requirements/test.txt
-    #   openai
-django==4.2.24
+django==4.2.25
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
@@ -175,7 +160,7 @@ edx-ccx-keys==2.0.2
     # via
     #   -r requirements/test.txt
     #   openedx-events
-edx-django-utils==8.0.0
+edx-django-utils==8.0.1
     # via
     #   -r requirements/test.txt
     #   edx-rest-api-client
@@ -206,29 +191,15 @@ filelock==3.19.1
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
-h11==0.16.0
-    # via
-    #   -r requirements/test.txt
-    #   httpcore
-httpcore==1.0.9
-    # via
-    #   -r requirements/test.txt
-    #   httpx
-httpx==0.28.1
-    # via
-    #   -r requirements/test.txt
-    #   openai
 idna==3.10
     # via
     #   -r requirements/test.txt
-    #   anyio
-    #   httpx
     #   requests
 iniconfig==2.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
-isort==6.0.1
+isort==6.1.0
     # via
     #   -r requirements/dev.in
     #   pylint
@@ -237,10 +208,6 @@ jinja2==3.1.6
     #   -r requirements/test.txt
     #   code-annotations
     #   diff-cover
-jiter==0.11.0
-    # via
-    #   -r requirements/test.txt
-    #   openai
 jmespath==1.0.1
     # via
     #   -r requirements/test.txt
@@ -254,7 +221,7 @@ lxml[html-clean]==6.0.2
     # via
     #   edx-i18n-tools
     #   lxml-html-clean
-lxml-html-clean==0.4.2
+lxml-html-clean==0.4.3
     # via lxml
 markupsafe==3.0.3
     # via
@@ -263,8 +230,6 @@ markupsafe==3.0.3
 mccabe==0.7.0
     # via pylint
 mock==5.2.0
-    # via -r requirements/test.txt
-openai==1.109.1
     # via -r requirements/test.txt
 openedx-events==10.5.0
     # via -r requirements/test.txt
@@ -282,7 +247,7 @@ path==13.1.0
     # via
     #   -c requirements/constraints.txt
     #   edx-i18n-tools
-pip-tools==7.5.0
+pip-tools==7.5.1
     # via -r requirements/pip-tools.txt
 platformdirs==4.4.0
     # via
@@ -314,14 +279,6 @@ pycparser==2.23
     # via
     #   -r requirements/test.txt
     #   cffi
-pydantic==2.11.9
-    # via
-    #   -r requirements/test.txt
-    #   openai
-pydantic-core==2.33.2
-    # via
-    #   -r requirements/test.txt
-    #   pydantic
 pydocstyle==6.3.0
     # via -r requirements/dev.in
 pygments==2.19.2
@@ -333,7 +290,7 @@ pyjwt==2.10.1
     # via
     #   -r requirements/test.txt
     #   edx-rest-api-client
-pylint==3.3.8
+pylint==3.3.9
     # via
     #   edx-lint
     #   pylint-celery
@@ -347,7 +304,7 @@ pylint-plugin-utils==0.9.0
     # via
     #   pylint-celery
     #   pylint-django
-pymongo==4.15.1
+pymongo==4.15.2
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -408,11 +365,6 @@ six==1.17.0
     #   edx-ccx-keys
     #   edx-lint
     #   python-dateutil
-sniffio==1.3.1
-    # via
-    #   -r requirements/test.txt
-    #   anyio
-    #   openai
 snowballstemmer==3.0.1
     # via pydocstyle
 soupsieve==2.8
@@ -437,26 +389,13 @@ text-unidecode==1.3
     #   python-slugify
 tomlkit==0.13.3
     # via pylint
-tox==4.30.2
+tox==4.30.3
     # via -r requirements/ci.txt
-tqdm==4.67.1
-    # via
-    #   -r requirements/test.txt
-    #   openai
 typing-extensions==4.15.0
     # via
     #   -r requirements/test.txt
-    #   anyio
     #   beautifulsoup4
     #   edx-opaque-keys
-    #   openai
-    #   pydantic
-    #   pydantic-core
-    #   typing-inspection
-typing-inspection==0.4.1
-    # via
-    #   -r requirements/test.txt
-    #   pydantic
 tzdata==2025.2
     # via
     #   -r requirements/test.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -16,20 +16,11 @@ amqp==5.3.1
     # via
     #   -r requirements/test.txt
     #   kombu
-annotated-types==0.7.0
-    # via
-    #   -r requirements/test.txt
-    #   pydantic
-anyio==4.11.0
-    # via
-    #   -r requirements/test.txt
-    #   httpx
-    #   openai
-asgiref==3.9.2
+asgiref==3.10.0
     # via
     #   -r requirements/test.txt
     #   django
-attrs==25.3.0
+attrs==25.4.0
     # via
     #   -r requirements/test.txt
     #   openedx-events
@@ -37,7 +28,7 @@ babel==2.17.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.14.0
+beautifulsoup4==4.14.2
     # via
     #   -r requirements/test.txt
     #   pydata-sphinx-theme
@@ -45,11 +36,11 @@ billiard==4.2.2
     # via
     #   -r requirements/test.txt
     #   celery
-boto3==1.40.40
+boto3==1.40.46
     # via
     #   -r requirements/test.txt
     #   django-ses
-botocore==1.40.40
+botocore==1.40.46
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -58,16 +49,13 @@ build==1.3.0
     # via -r requirements/doc.in
 celery==5.5.3
     # via -r requirements/test.txt
-certifi==2025.8.3
+certifi==2025.10.5
     # via
     #   -r requirements/test.txt
-    #   httpcore
-    #   httpx
     #   requests
 cffi==2.0.0
     # via
     #   -r requirements/test.txt
-    #   cryptography
     #   pynacl
 charset-normalizer==3.4.3
     # via
@@ -100,15 +88,9 @@ coverage[toml]==7.10.7
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==46.0.1
-    # via secretstorage
 ddt==1.7.2
     # via -r requirements/test.txt
-distro==1.9.0
-    # via
-    #   -r requirements/test.txt
-    #   openai
-django==4.2.24
+django==4.2.25
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
@@ -161,7 +143,7 @@ edx-ccx-keys==2.0.2
     # via
     #   -r requirements/test.txt
     #   openedx-events
-edx-django-utils==8.0.0
+edx-django-utils==8.0.1
     # via
     #   -r requirements/test.txt
     #   edx-rest-api-client
@@ -183,25 +165,11 @@ fastavro==1.12.0
     # via
     #   -r requirements/test.txt
     #   openedx-events
-h11==0.16.0
-    # via
-    #   -r requirements/test.txt
-    #   httpcore
-httpcore==1.0.9
-    # via
-    #   -r requirements/test.txt
-    #   httpx
-httpx==0.28.1
-    # via
-    #   -r requirements/test.txt
-    #   openai
 id==1.5.0
     # via twine
 idna==3.10
     # via
     #   -r requirements/test.txt
-    #   anyio
-    #   httpx
     #   requests
 imagesize==1.4.1
     # via sphinx
@@ -215,19 +183,11 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.3.0
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6
     # via
     #   -r requirements/test.txt
     #   code-annotations
     #   sphinx
-jiter==0.11.0
-    # via
-    #   -r requirements/test.txt
-    #   openai
 jmespath==1.0.1
     # via
     #   -r requirements/test.txt
@@ -253,10 +213,8 @@ more-itertools==10.8.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-nh3==0.3.0
+nh3==0.3.1
     # via readme-renderer
-openai==1.109.1
-    # via -r requirements/test.txt
 openedx-events==10.5.0
     # via -r requirements/test.txt
 packaging==25.0
@@ -285,14 +243,6 @@ pycparser==2.23
     # via
     #   -r requirements/test.txt
     #   cffi
-pydantic==2.11.9
-    # via
-    #   -r requirements/test.txt
-    #   openai
-pydantic-core==2.33.2
-    # via
-    #   -r requirements/test.txt
-    #   pydantic
 pydata-sphinx-theme==0.15.4
     # via sphinx-book-theme
 pygments==2.19.2
@@ -309,7 +259,7 @@ pyjwt==2.10.1
     # via
     #   -r requirements/test.txt
     #   edx-rest-api-client
-pymongo==4.15.1
+pymongo==4.15.2
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -372,18 +322,11 @@ s3transfer==0.14.0
     # via
     #   -r requirements/test.txt
     #   boto3
-secretstorage==3.4.0
-    # via keyring
 six==1.17.0
     # via
     #   -r requirements/test.txt
     #   edx-ccx-keys
     #   python-dateutil
-sniffio==1.3.1
-    # via
-    #   -r requirements/test.txt
-    #   anyio
-    #   openai
 snowballstemmer==3.0.1
     # via sphinx
 soupsieve==2.8
@@ -426,27 +369,14 @@ text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-tqdm==4.67.1
-    # via
-    #   -r requirements/test.txt
-    #   openai
 twine==6.2.0
     # via -r requirements/doc.in
 typing-extensions==4.15.0
     # via
     #   -r requirements/test.txt
-    #   anyio
     #   beautifulsoup4
     #   edx-opaque-keys
-    #   openai
-    #   pydantic
-    #   pydantic-core
     #   pydata-sphinx-theme
-    #   typing-inspection
-typing-inspection==0.4.1
-    # via
-    #   -r requirements/test.txt
-    #   pydantic
 tzdata==2025.2
     # via
     #   -r requirements/test.txt

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,7 +10,7 @@ click==8.3.0
     # via pip-tools
 packaging==25.0
     # via build
-pip-tools==7.5.0
+pip-tools==7.5.1
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,33 +10,24 @@ algoliasearch==1.20.0
     #   -r requirements/base.in
 amqp==5.3.1
     # via kombu
-annotated-types==0.7.0
-    # via pydantic
-anyio==4.11.0
-    # via
-    #   httpx
-    #   openai
-asgiref==3.9.2
+asgiref==3.10.0
     # via django
-attrs==25.3.0
+attrs==25.4.0
     # via openedx-events
-beautifulsoup4==4.14.0
+beautifulsoup4==4.14.2
     # via -r requirements/base.in
 billiard==4.2.2
     # via celery
-boto3==1.40.40
+boto3==1.40.46
     # via django-ses
-botocore==1.40.40
+botocore==1.40.46
     # via
     #   boto3
     #   s3transfer
 celery==5.5.3
     # via -r requirements/base.in
-certifi==2025.8.3
-    # via
-    #   httpcore
-    #   httpx
-    #   requests
+certifi==2025.10.5
+    # via requests
 cffi==2.0.0
     # via pynacl
 charset-normalizer==3.4.3
@@ -61,8 +52,6 @@ coverage[toml]==7.10.7
     # via pytest-cov
 ddt==1.7.2
     # via -r requirements/test.in
-distro==1.9.0
-    # via openai
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -98,7 +87,7 @@ dnspython==2.8.0
     # via pymongo
 edx-ccx-keys==2.0.2
     # via openedx-events
-edx-django-utils==8.0.0
+edx-django-utils==8.0.1
     # via
     #   -r requirements/base.in
     #   edx-rest-api-client
@@ -118,23 +107,12 @@ faker==37.8.0
     #   factory-boy
 fastavro==1.12.0
     # via openedx-events
-h11==0.16.0
-    # via httpcore
-httpcore==1.0.9
-    # via httpx
-httpx==0.28.1
-    # via openai
 idna==3.10
-    # via
-    #   anyio
-    #   httpx
-    #   requests
+    # via requests
 iniconfig==2.1.0
     # via pytest
 jinja2==3.1.6
     # via code-annotations
-jiter==0.11.0
-    # via openai
 jmespath==1.0.1
     # via
     #   boto3
@@ -145,8 +123,6 @@ markupsafe==3.0.3
     # via jinja2
 mock==5.2.0
     # via -r requirements/test.in
-openai==1.109.1
-    # via -r requirements/base.in
 openedx-events==10.5.0
     # via -r requirements/base.in
 packaging==25.0
@@ -163,15 +139,11 @@ psutil==7.1.0
     # via edx-django-utils
 pycparser==2.23
     # via cffi
-pydantic==2.11.9
-    # via openai
-pydantic-core==2.33.2
-    # via pydantic
 pygments==2.19.2
     # via pytest
 pyjwt==2.10.1
     # via edx-rest-api-client
-pymongo==4.15.1
+pymongo==4.15.2
     # via edx-opaque-keys
 pynacl==1.6.0
     # via edx-django-utils
@@ -208,10 +180,6 @@ six==1.17.0
     # via
     #   edx-ccx-keys
     #   python-dateutil
-sniffio==1.3.1
-    # via
-    #   anyio
-    #   openai
 soupsieve==2.8
     # via beautifulsoup4
 sqlparse==0.5.3
@@ -225,19 +193,10 @@ testfixtures==9.1.0
     # via -r requirements/test.in
 text-unidecode==1.3
     # via python-slugify
-tqdm==4.67.1
-    # via openai
 typing-extensions==4.15.0
     # via
-    #   anyio
     #   beautifulsoup4
     #   edx-opaque-keys
-    #   openai
-    #   pydantic
-    #   pydantic-core
-    #   typing-inspection
-typing-inspection==0.4.1
-    # via pydantic
 tzdata==2025.2
     # via
     #   faker


### PR DESCRIPTION
Remove unused openai pypi pkg.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
- [ ] [Version](https://github.com/openedx/taxonomy-connector/blob/master/taxonomy/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/taxonomy-connector/blob/master/CHANGELOG.rst) record added

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/taxonomy-connector/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/taxonomy-connector/actions), verify version has been pushed to [PyPI](https://pypi.org/project/taxonomy-connector/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [course-discovery](https://github.com/openedx/course-discovery) to upgrade dependencies (including taxonomy-connector)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in course-discovery will look for the latest version in PyPi.